### PR TITLE
Remove the meta header and rename references to OpenSearch

### DIFF
--- a/opensearch/src/cert.rs
+++ b/opensearch/src/cert.rs
@@ -53,9 +53,9 @@ use std::{
 ///
 /// ## Full validation
 ///
-/// With Elasticsearch running at `https://example.com`, configured to use a certificate generated
+/// With OpenSearch running at `https://example.com`, configured to use a certificate generated
 /// with your own Certificate Authority (CA), and where the certificate contains a CommonName (CN)
-/// or Subject Alternative Name (SAN) that matches the hostname of Elasticsearch
+/// or Subject Alternative Name (SAN) that matches the hostname of OpenSearch
 #[cfg_attr(
     any(feature = "native-tls", feature = "rustls-tls"),
     doc = r##"
@@ -82,7 +82,7 @@ let cert = Certificate::from_pem(&buf)?;
 let transport = TransportBuilder::new(conn_pool)
     .cert_validation(CertificateValidation::Full(cert))
     .build()?;
-let client = Elasticsearch::new(transport);
+let client = OpenSearch::new(transport);
 let _response = client.ping().send().await?;
 # Ok(())
 # }
@@ -93,7 +93,7 @@ let _response = client.ping().send().await?;
 ///
 /// This requires the `native-tls` feature to be enabled.
 ///
-/// With Elasticsearch running at `https://example.com`, configured to use a certificate generated
+/// With OpenSearch running at `https://example.com`, configured to use a certificate generated
 /// with your own Certificate Authority (CA)
 #[cfg_attr(
     feature = "native-tls",
@@ -120,7 +120,7 @@ let cert = Certificate::from_pem(&buf)?;
 let transport = TransportBuilder::new(conn_pool)
     .cert_validation(CertificateValidation::Certificate(cert))
     .build()?;
-let client = Elasticsearch::new(transport);
+let client = OpenSearch::new(transport);
 let _response = client.ping().send().await?;
 # Ok(())
 # }

--- a/opensearch/src/generated/root.rs
+++ b/opensearch/src/generated/root.rs
@@ -8272,7 +8272,7 @@ where
         Ok(response)
     }
 }
-impl Elasticsearch {
+impl OpenSearch {
     #[doc = "[Bulk API](https://opensearch.org/)\n\nAllows to perform multiple index/update/delete operations in a single request."]
     pub fn bulk<'a, 'b>(&'a self, parts: BulkParts<'b>) -> Bulk<'a, 'b, ()> {
         Bulk::new(self.transport(), parts)

--- a/opensearch/tests/client.rs
+++ b/opensearch/tests/client.rs
@@ -244,7 +244,7 @@ async fn serialize_querystring() -> Result<(), failure::Error> {
         assert_eq!(req.uri().path(), "/_search");
         assert_eq!(
                 req.uri().query(),
-                Some("filter_path=took%2C_shards&pretty=true&q=title%3AElasticsearch&track_total_hits=100000")
+                Some("filter_path=took%2C_shards&pretty=true&q=title%3AOpenSearch&track_total_hits=100000")
             );
         http::Response::default()
     });
@@ -255,7 +255,7 @@ async fn serialize_querystring() -> Result<(), failure::Error> {
         .pretty(true)
         .filter_path(&["took", "_shards"])
         .track_total_hits(TrackTotalHits::Count(100_000))
-        .q("title:Elasticsearch")
+        .q("title:OpenSearch")
         .send()
         .await?;
 
@@ -313,7 +313,7 @@ async fn search_with_no_body() -> Result<(), failure::Error> {
     let response = client
         .search(SearchParts::None)
         .pretty(true)
-        .q("title:Elasticsearch")
+        .q("title:OpenSearch")
         .send()
         .await?;
 
@@ -336,7 +336,7 @@ async fn read_response_as_bytes() -> Result<(), failure::Error> {
     let response = client
         .search(SearchParts::None)
         .pretty(true)
-        .q("title:Elasticsearch")
+        .q("title:OpenSearch")
         .send()
         .await?;
 
@@ -427,7 +427,7 @@ async fn clone_search_with_body() -> Result<(), failure::Error> {
     let _ = index_documents(&client).await?;
     let base_request = client.search(SearchParts::None);
 
-    let request_clone = base_request.clone().q("title:Elasticsearch").size(1);
+    let request_clone = base_request.clone().q("title:OpenSearch").size(1);
 
     let _request = base_request
         .body(json!({

--- a/yaml_test_runner/src/main.rs
+++ b/yaml_test_runner/src/main.rs
@@ -64,17 +64,17 @@ fn main() -> Result<(), failure::Error> {
             .short("u")
             .long("url")
             .value_name("OPENSEARCH_URL")
-            .help("The url of a running Elasticsearch cluster. Used to determine the version, test suite and branch to use to compile tests")
+            .help("The url of a running OpenSearch cluster. Used to determine the version, test suite and branch to use to compile tests")
             .required(true)
             .takes_value(true))
         .get_matches();
 
     let url = matches.value_of("url").expect("missing 'url' argument");
-    let (branch, suite, version) = match branch_suite_and_version_from_elasticsearch(url) {
+    let (branch, suite, version) = match branch_suite_and_version_from_opensearch(url) {
         Ok(v) => v,
         Err(e) => {
             error!(
-                "Problem getting values from Elasticsearch at {}. {:?}",
+                "Problem getting values from OpenSearch at {}. {:?}",
                 url, e
             );
             exit(1);
@@ -153,7 +153,7 @@ fn main() -> Result<(), failure::Error> {
     Ok(())
 }
 
-fn branch_suite_and_version_from_elasticsearch(
+fn branch_suite_and_version_from_opensearch(
     url: &str,
 ) -> Result<(String, TestSuite, semver::Version), failure::Error> {
     let client = reqwest::ClientBuilder::new()


### PR DESCRIPTION
### Description
Remove the `meta_header` support from the code base. 
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-rs/issues/26
 
###
CI passing locally for an Open Distro cluster. 
```
INFO: Removing volume instance-rest-test-data
instance-rest-test-data
INFO: Removing network search-rest-test
search-rest-test
SUCCESS: Cleaned up and exiting

SUCCESS run-tests
INFO: clean the network if not detached (start and exit)
INFO: search-rest-test is already deleted

SUCCESS run-tests

```


### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).