### PR TITLE
Add the support to run tests for an opensearch cluster 

### DIFF
--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cluster-type: ['opendistro']
+        cluster-type: ['opendistro', 'opensearch']
 
     steps:
       - name: Checkout

--- a/yaml_test_runner/src/github.rs
+++ b/yaml_test_runner/src/github.rs
@@ -53,7 +53,7 @@ pub fn download_test_suites(branch: &str, download_dir: &PathBuf) -> Result<(), 
 
     info!("Downloading yaml tests from {}", branch);
     let url = format!(
-        "https://api.github.com/repos/elastic/elasticsearch/tarball/{}",
+        "https://api.github.com/repos/opensearch-project/opensearch/tarball/{}",
         branch
     );
     let mut headers = HeaderMap::new();


### PR DESCRIPTION
### Description
Updating the elastic endpoint to an opensearch endpoint
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-rs/issues/14
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
