### PR TITLE
Add support to run tests against unreleased OpenSearch

### DIFF
--- a/.github/workflows/test-integrations-unreleased.yml
+++ b/.github/workflows/test-integrations-unreleased.yml
@@ -1,0 +1,55 @@
+name: Integration with Unreleased OpenSearch
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        entry:
+          - { opensearch_ref: '1.x' }
+          - { opensearch_ref: '2.0' }
+          - { opensearch_ref: '2.x' }
+          - { opensearch_ref: 'main' }
+    steps:
+      - name: Checkout OpenSearch
+        uses: actions/checkout@v2
+        with:
+          repository: opensearch-project/opensearch
+          ref: ${{ matrix.entry.opensearch_ref }}
+          path: opensearch
+
+        # This step builds the docker image tagged as opensearch:test. It will be further used in /ci/run-tests to test against unreleased OpenSearch.
+        # Reference: https://github.com/opensearch-project/OpenSearch/blob/2.0/distribution/docker/build.gradle#L190
+      - name: Assemble OpenSearch
+        run: |
+          cd opensearch
+          ./gradlew assemble
+
+      - name: Checkout Rust Client
+        uses: actions/checkout@v2
+
+      - name: Increase system limits
+        run: |
+          sudo swapoff -a
+          sudo sysctl -w vm.swappiness=1
+          sudo sysctl -w fs.file-max=262144
+          sudo sysctl -w vm.max_map_count=262144
+
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly
+            override: true
+            components: rustfmt, clippy
+
+      - name: Integ OpenSearch ${{ matrix.entry.opensearch_ref }} secured=false
+        run: "./.ci/run-tests opensearch SNAPSHOT false"

--- a/.github/workflows/test-integrations-unreleased.yml
+++ b/.github/workflows/test-integrations-unreleased.yml
@@ -1,12 +1,6 @@
 name: Integration with Unreleased OpenSearch
 
-on:
-  push:
-    branches:
-      - "main"
-  pull_request:
-    branches:
-      - "main"
+on: [push, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
Adding workflow and test support to run tests against unreleased OpenSearch versions. This helps in getting the client ready for upcoming releases.

### Issues Resolved
Part of #39 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
