### PR TITLE
Relax aws-sdk dependency versions

### DIFF
--- a/opensearch/Cargo.toml
+++ b/opensearch/Cargo.toml
@@ -40,11 +40,11 @@ serde = { version = "~1", features = ["derive"] }
 serde_json = "~1"
 serde_with = "~1"
 void = "1.0.2"
-aws-sigv4 = { version = "0.10", optional = true }
-aws-types = { version = "0.10", optional = true }
+aws-sigv4 = { version = ">= 0.10", optional = true }
+aws-types = { version = ">= 0.10", optional = true }
 
 [dev-dependencies]
-aws-config = "0.10"
+aws-config = ">= 0.10"
 chrono = { version = "^0.4", features = ["serde"] }
 clap = "~2"
 failure = "0.1.5"

--- a/opensearch/src/http/request.rs
+++ b/opensearch/src/http/request.rs
@@ -265,7 +265,7 @@ mod tests {
         let mut bytes_mut = BytesMut::with_capacity(21);
         let bytes: &'static [u8] = b"{\"foo\":\"bar\",\"baz\":1}";
         let _ = bytes.write(&mut bytes_mut)?;
-        assert_eq!(&bytes[..], &bytes_mut[..]);
+        assert_eq!(bytes, &bytes_mut[..]);
 
         Ok(())
     }

--- a/opensearch/src/http/response.rs
+++ b/opensearch/src/http/response.rs
@@ -53,8 +53,8 @@ impl Response {
     /// Creates a new instance of an Elasticsearch response
     pub fn new(response: reqwest::Response, method: Method) -> Self {
         Self {
-            response: response,
-            method: method,
+            response,
+            method,
         }
     }
 
@@ -478,7 +478,7 @@ pub mod tests {
             Some("Missing mandatory contexts in context query")
         );
 
-        assert!(error.additional_details().len() > 0);
+        assert!(!error.additional_details().is_empty());
         assert_eq!(
             error.additional_details().get("phase"),
             Some(&json!("query"))


### PR DESCRIPTION
### Description
Specifying a fixed `0.10` only allows patch updates, which causes issues if trying to use for example `0.12` in a parent project, as handling of major version zero is different to one and up due to semver guarantees. ie. `0.10` is equivalent to `>=0.10.0, <0.11.0` where as `1.10` is equivalent to `>=1.10.0, <2.0.0`.

Also fix a couple minor clippy lints while I'm here.

### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Thomas Farr <xtansia@xtansia.com>
