### PR TITLE
Fix unescaped chars in docs

### DIFF
--- a/api_generator/Cargo.toml
+++ b/api_generator/Cargo.toml
@@ -34,6 +34,7 @@ tar = "~0.4"
 toml = "0.5.6"
 url = "2.1.1"
 void = "1.0.2"
+html-escape = "0.2.11"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/api_generator/src/generator/code_gen/mod.rs
+++ b/api_generator/src/generator/code_gen/mod.rs
@@ -72,6 +72,10 @@ fn doc<I: Into<String>>(comment: I) -> syn::Attribute {
     }
 }
 
+fn doc_escaped<S: ?Sized + AsRef<str>>(comment: &S) -> syn::Attribute {
+    doc(html_escape::encode_text(comment))
+}
+
 fn stability_doc(stability: Stability) -> Option<syn::Attribute> {
     match stability {
         Stability::Experimental => Some(doc(r#"&nbsp;

--- a/api_generator/src/generator/code_gen/params.rs
+++ b/api_generator/src/generator/code_gen/params.rs
@@ -61,7 +61,7 @@ fn generate_param(tokens: &mut Tokens, e: &ApiEnum) {
         .unzip();
 
     let doc = match &e.description {
-        Some(description) => Some(code_gen::doc(description)),
+        Some(description) => Some(code_gen::doc_escaped(description)),
         None => None,
     };
 

--- a/api_generator/src/generator/code_gen/request/request_builder.rs
+++ b/api_generator/src/generator/code_gen/request/request_builder.rs
@@ -433,7 +433,7 @@ impl<'a> RequestBuilder<'a> {
         let impl_ident = ident(&name);
         let field_ident = ident(&name);
         let doc_attr = match &f.1.description {
-            Some(docs) => vec![doc(docs)],
+            Some(docs) => vec![doc_escaped(docs)],
             _ => vec![],
         };
 

--- a/opensearch/src/root/mod.rs
+++ b/opensearch/src/root/mod.rs
@@ -1606,7 +1606,7 @@ where
         self.slices = Some(slices);
         self
     }
-    #[doc = "A comma-separated list of <field>:<direction> pairs"]
+    #[doc = "A comma-separated list of &lt;field&gt;:&lt;direction&gt; pairs"]
     pub fn sort(mut self, sort: &'b [&'b str]) -> Self {
         self.sort = Some(sort);
         self
@@ -6937,7 +6937,7 @@ where
         self.size = Some(size);
         self
     }
-    #[doc = "A comma-separated list of <field>:<direction> pairs"]
+    #[doc = "A comma-separated list of &lt;field&gt;:&lt;direction&gt; pairs"]
     pub fn sort(mut self, sort: &'b [&'b str]) -> Self {
         self.sort = Some(sort);
         self
@@ -8515,7 +8515,7 @@ where
         self.slices = Some(slices);
         self
     }
-    #[doc = "A comma-separated list of <field>:<direction> pairs"]
+    #[doc = "A comma-separated list of &lt;field&gt;:&lt;direction&gt; pairs"]
     pub fn sort(mut self, sort: &'b [&'b str]) -> Self {
         self.sort = Some(sort);
         self


### PR DESCRIPTION
### Description
Fixes unescaped `<` & `>` chars in generated code docs

### Issues Resolved
Resolves #61 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
