### PR TITLE
Fix the large number of clippy lints

### DIFF
--- a/api_generator/src/bin/run.rs
+++ b/api_generator/src/bin/run.rs
@@ -73,7 +73,7 @@ fn main() -> Result<(), failure::Error> {
         fs::remove_dir_all(&download_dir)?;
         fs::create_dir_all(&download_dir)?;
         rest_spec::download_specs(&branch, &download_dir)?;
-        File::create(&last_downloaded_version)?.write_all(branch.as_bytes())?;
+        File::create(last_downloaded_version)?.write_all(branch.as_bytes())?;
     }
 
     // only offer to generate if there are downloaded specs

--- a/api_generator/src/bin/run.rs
+++ b/api_generator/src/bin/run.rs
@@ -16,15 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-extern crate api_generator;
-extern crate dialoguer;
 
 use api_generator::{generator, rest_spec};
 use dialoguer::Input;
 use std::{
     fs::{self, File},
     io::Write,
-    path::PathBuf,
+    path::Path,
 };
 
 fn main() -> Result<(), failure::Error> {
@@ -34,15 +32,14 @@ fn main() -> Result<(), failure::Error> {
         .unwrap();
 
     // This must be run from the repo root directory, with cargo make generate-api
-    let download_dir = fs::canonicalize(PathBuf::from("./api_generator/rest_specs"))?;
-    let generated_dir = fs::canonicalize(PathBuf::from("./opensearch/src"))?;
-    let last_downloaded_version =
-        PathBuf::from("./api_generator/rest_specs/last_downloaded_version");
+    let download_dir = fs::canonicalize(Path::new("./api_generator/rest_specs"))?;
+    let generated_dir = fs::canonicalize(Path::new("./opensearch/src"))?;
+    let last_downloaded_version = Path::new("./api_generator/rest_specs/last_downloaded_version");
 
     let mut download_specs = false;
     let mut answer = String::new();
     let default_branch = if last_downloaded_version.exists() {
-        fs::read_to_string(&last_downloaded_version)?
+        fs::read_to_string(last_downloaded_version)?
     } else {
         String::from("master")
     };

--- a/api_generator/src/generator/code_gen/mod.rs
+++ b/api_generator/src/generator/code_gen/mod.rs
@@ -67,7 +67,7 @@ fn ident<I: AsRef<str>>(name: I) -> syn::Ident {
 fn doc<I: Into<String>>(comment: I) -> syn::Attribute {
     syn::Attribute {
         style: syn::AttrStyle::Outer,
-        value: syn::MetaItem::NameValue(ident("doc".to_string()), lit(comment)),
+        value: syn::MetaItem::NameValue(ident("doc"), lit(comment)),
         is_sugared_doc: true,
     }
 }
@@ -94,7 +94,7 @@ happen in minor versions.
 
 /// AST for an expression parsed from quoted tokens
 pub fn parse_expr(input: quote::Tokens) -> syn::Expr {
-    syn::parse_expr(input.to_string().as_ref()).unwrap()
+    syn::parse_expr(input.as_str()).unwrap()
 }
 
 /// Ensures that the name generated is one that is valid for Rust

--- a/api_generator/src/generator/code_gen/mod.rs
+++ b/api_generator/src/generator/code_gen/mod.rs
@@ -140,7 +140,7 @@ pub trait GetPath {
 impl GetPath for syn::Ty {
     fn get_path(&self) -> &syn::Path {
         match *self {
-            syn::Ty::Path(_, ref p) => &p,
+            syn::Ty::Path(_, ref p) => p,
             ref p => panic!("Expected syn::Ty::Path, but found {:?}", p),
         }
     }
@@ -148,7 +148,7 @@ impl GetPath for syn::Ty {
 
 impl GetPath for syn::Path {
     fn get_path(&self) -> &syn::Path {
-        &self
+        self
     }
 }
 

--- a/api_generator/src/generator/code_gen/mod.rs
+++ b/api_generator/src/generator/code_gen/mod.rs
@@ -176,7 +176,7 @@ fn typekind_to_ty(name: &str, kind: &TypeKind, required: bool, fn_arg: bool) -> 
         TypeKind::List => {
             v.push_str("&'b [");
             v.push_str(str_type);
-            v.push_str("]");
+            v.push(']');
         }
         TypeKind::Enum => match name {
             // opened https://github.com/elastic/elasticsearch/issues/53212
@@ -185,7 +185,7 @@ fn typekind_to_ty(name: &str, kind: &TypeKind, required: bool, fn_arg: bool) -> 
                 // Expand wildcards should
                 v.push_str("&'b [");
                 v.push_str(name.to_pascal_case().as_str());
-                v.push_str("]");
+                v.push(']');
             }
             _ => v.push_str(name.to_pascal_case().as_str()),
         },
@@ -215,7 +215,7 @@ fn typekind_to_ty(name: &str, kind: &TypeKind, required: bool, fn_arg: bool) -> 
     };
 
     if !required {
-        v.push_str(">");
+        v.push('>');
     }
 
     syn::parse_type(v.as_str()).unwrap()

--- a/api_generator/src/generator/code_gen/namespace_clients.rs
+++ b/api_generator/src/generator/code_gen/namespace_clients.rs
@@ -60,7 +60,7 @@ pub fn generate(api: &Api, docs_dir: &Path) -> Result<Vec<(String, String)>, fai
             "Creates a new instance of [{}]",
             &namespace_pascal_case
         ));
-        let namespace_name = ident(namespace_name.to_string());
+        let namespace_name = ident(namespace_name);
 
         let (builders, methods): (Vec<Tokens>, Vec<Tokens>) = namespace
             .endpoints()

--- a/api_generator/src/generator/code_gen/namespace_clients.rs
+++ b/api_generator/src/generator/code_gen/namespace_clients.rs
@@ -16,16 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-use crate::generator::{
-    code_gen::{request::request_builder::RequestBuilder, *},
-    *,
-};
+use crate::generator::{code_gen::request::request_builder::RequestBuilder, Api};
 use inflector::Inflector;
 use quote::Tokens;
-use std::path::PathBuf;
+use std::path::Path;
+
+use super::{doc, ident, stability_doc, use_declarations};
 
 /// Generates the source code for a namespaced client
-pub fn generate(api: &Api, docs_dir: &PathBuf) -> Result<Vec<(String, String)>, failure::Error> {
+pub fn generate(api: &Api, docs_dir: &Path) -> Result<Vec<(String, String)>, failure::Error> {
     let mut output = Vec::new();
 
     for (namespace_name, namespace) in &api.namespaces {

--- a/api_generator/src/generator/code_gen/namespace_clients.rs
+++ b/api_generator/src/generator/code_gen/namespace_clients.rs
@@ -40,7 +40,7 @@ pub fn generate(api: &Api, docs_dir: &Path) -> Result<Vec<(String, String)>, fai
         tokens.append(use_declarations());
 
         let namespace_pascal_case = namespace_name.to_pascal_case();
-        let namespace_replaced_pascal_case = namespace_name.replace("_", " ").to_pascal_case();
+        let namespace_replaced_pascal_case = namespace_name.replace('_', " ").to_pascal_case();
         let namespace_client_name = ident(&namespace_pascal_case);
         let name_for_docs = match namespace_replaced_pascal_case.as_ref() {
             "Ccr" => "Cross Cluster Replication",

--- a/api_generator/src/generator/code_gen/namespace_clients.rs
+++ b/api_generator/src/generator/code_gen/namespace_clients.rs
@@ -73,7 +73,7 @@ pub fn generate(api: &Api, docs_dir: &Path) -> Result<Vec<(String, String)>, fai
                     name,
                     &builder_name,
                     &api.common_params,
-                    &endpoint,
+                    endpoint,
                     false,
                 )
                 .build()

--- a/api_generator/src/generator/code_gen/params.rs
+++ b/api_generator/src/generator/code_gen/params.rs
@@ -69,7 +69,7 @@ fn generate_param(tokens: &mut Tokens, e: &ApiEnum) {
         #doc
         #cfg_doc
         #cfg_attr
-        #[derive(Debug, PartialEq, Deserialize, Serialize, Clone, Copy)]
+        #[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone, Copy)]
         pub enum #name {
             #(#[serde(rename = #renames)] #variants),*
         }

--- a/api_generator/src/generator/code_gen/params.rs
+++ b/api_generator/src/generator/code_gen/params.rs
@@ -60,10 +60,7 @@ fn generate_param(tokens: &mut Tokens, e: &ApiEnum) {
         })
         .unzip();
 
-    let doc = match &e.description {
-        Some(description) => Some(code_gen::doc_escaped(description)),
-        None => None,
-    };
+    let doc = e.description.as_ref().map(code_gen::doc_escaped);
 
     let cfg_attr = e.stability.outer_cfg_attr();
     let cfg_doc = stability_doc(e.stability);

--- a/api_generator/src/generator/code_gen/params.rs
+++ b/api_generator/src/generator/code_gen/params.rs
@@ -27,7 +27,7 @@ pub fn generate(api: &Api) -> Result<String, failure::Error> {
         use serde::{Serialize, Deserialize};
     );
     for e in &api.enums {
-        generate_param(&mut tokens, &e);
+        generate_param(&mut tokens, e);
     }
 
     let generated = tokens.to_string();

--- a/api_generator/src/generator/code_gen/request/request_builder.rs
+++ b/api_generator/src/generator/code_gen/request/request_builder.rs
@@ -24,13 +24,13 @@ use crate::generator::{
 use inflector::Inflector;
 use quote::{ToTokens, Tokens};
 use reqwest::Url;
-use std::{collections::BTreeMap, fs, path::PathBuf, str};
+use std::{collections::BTreeMap, fs, path::Path, str};
 use syn::{Field, FieldValue, ImplItem, TraitBoundModifier, TyParamBound};
 
 /// Builder that generates the AST for a request builder struct
 pub struct RequestBuilder<'a> {
     /// Path to markdown docs that may be combined with generated docs
-    docs_dir: &'a PathBuf,
+    docs_dir: &'a Path,
     /// The namespace of the API
     namespace_name: &'a str,
     /// The name of the API to which the generated struct relates
@@ -51,7 +51,7 @@ pub struct RequestBuilder<'a> {
 
 impl<'a> RequestBuilder<'a> {
     pub fn new(
-        docs_dir: &'a PathBuf,
+        docs_dir: &'a Path,
         namespace_name: &'a str,
         name: &'a str,
         builder_name: &'a str,
@@ -669,7 +669,7 @@ impl<'a> RequestBuilder<'a> {
     /// Creates the AST for a fn that returns a new instance of a builder struct
     /// from the root or namespace client
     fn create_builder_struct_ctor_fns(
-        docs_dir: &PathBuf,
+        docs_dir: &Path,
         namespace_name: &str,
         name: &str,
         builder_name: &str,
@@ -697,7 +697,7 @@ impl<'a> RequestBuilder<'a> {
         let api_name_for_docs = split_on_pascal_case(builder_name);
 
         let markdown_doc = {
-            let mut path = docs_dir.clone();
+            let mut path = docs_dir.to_path_buf();
             path.push("functions");
             path.push(format!("{}.{}.md", namespace_name, name));
             if path.exists() {

--- a/api_generator/src/generator/code_gen/request/request_builder.rs
+++ b/api_generator/src/generator/code_gen/request/request_builder.rs
@@ -245,7 +245,7 @@ impl<'a> RequestBuilder<'a> {
         default_fields: &[&syn::Ident],
         accepts_nd_body: bool,
     ) -> syn::ImplItem {
-        let fields: Vec<FieldValue> = default_fields
+        let fields = default_fields
             .iter()
             .filter(|&&part| part != &ident("body"))
             .map(|&part| syn::FieldValue {
@@ -257,8 +257,7 @@ impl<'a> RequestBuilder<'a> {
                 )
                 .into(),
                 is_shorthand: false,
-            })
-            .collect();
+            });
 
         let (fn_arg, field_arg, ret_ty) = if accepts_nd_body {
             (

--- a/api_generator/src/generator/code_gen/request/request_builder.rs
+++ b/api_generator/src/generator/code_gen/request/request_builder.rs
@@ -401,9 +401,9 @@ impl<'a> RequestBuilder<'a> {
 
     /// Creates the AST for a builder fn for a builder impl
     fn create_impl_fn(f: (&String, &Type)) -> syn::ImplItem {
-        let name = valid_name(&f.0).to_lowercase();
+        let name = valid_name(f.0).to_lowercase();
         let (ty, value_ident, fn_generics) = {
-            let ty = typekind_to_ty(&f.0, &f.1.ty, true, true);
+            let ty = typekind_to_ty(f.0, &f.1.ty, true, true);
             match ty {
                 syn::Ty::Path(ref _q, ref p) => {
                     if p.get_ident().as_ref() == "Into" {
@@ -552,7 +552,7 @@ impl<'a> RequestBuilder<'a> {
         // add a body impl if supported
         if supports_body {
             let body_fn = Self::create_body_fn(
-                &builder_name,
+                builder_name,
                 &builder_ident,
                 &default_fields,
                 accepts_nd_body,
@@ -566,9 +566,9 @@ impl<'a> RequestBuilder<'a> {
         builder_fns.dedup_by(|a, b| a.ident.eq(&b.ident));
 
         let new_fn =
-            Self::create_new_fn(&builder_name, &builder_ident, enum_builder, &default_fields);
+            Self::create_new_fn(builder_name, &builder_ident, enum_builder, &default_fields);
 
-        let method_expr = Self::create_method_expression(&builder_name, &endpoint);
+        let method_expr = Self::create_method_expression(builder_name, endpoint);
 
         let query_string_params = {
             let mut p = endpoint.params.clone();
@@ -759,10 +759,10 @@ impl<'a> RequestBuilder<'a> {
     /// Creates the AST for a field for a struct
     fn create_struct_field(f: (&String, &Type)) -> syn::Field {
         syn::Field {
-            ident: Some(ident(valid_name(&f.0).to_lowercase())),
+            ident: Some(ident(valid_name(f.0).to_lowercase())),
             vis: syn::Visibility::Inherited,
             attrs: vec![],
-            ty: typekind_to_ty(&f.0, &f.1.ty, false, false),
+            ty: typekind_to_ty(f.0, &f.1.ty, false, false),
         }
     }
 

--- a/api_generator/src/generator/code_gen/root.rs
+++ b/api_generator/src/generator/code_gen/root.rs
@@ -1,31 +1,29 @@
 /*
- * Licensed to Elasticsearch B.V. under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch B.V. licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *	http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-use crate::generator::{
-    code_gen::{request::request_builder::RequestBuilder, *},
-    *,
-};
+* Licensed to Elasticsearch B.V. under one or more contributor
+* license agreements. See the NOTICE file distributed with
+* this work for additional information regarding copyright
+* ownership. Elasticsearch B.V. licenses this file to you under
+* the Apache License, Version 2.0 (the "License"); you may
+* not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*	http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+use super::{request::request_builder::RequestBuilder, use_declarations};
+use crate::generator::Api;
 use inflector::Inflector;
 use quote::Tokens;
-use std::path::PathBuf;
+use std::path::Path;
 
 /// Generates the source code for the methods on the root of Elasticsearch
-pub fn generate(api: &Api, docs_dir: &PathBuf) -> Result<String, failure::Error> {
+pub fn generate(api: &Api, docs_dir: &Path) -> Result<String, failure::Error> {
     let mut tokens = Tokens::new();
     tokens.append(use_declarations());
 

--- a/api_generator/src/generator/code_gen/url/enum_builder.rs
+++ b/api_generator/src/generator/code_gen/url/enum_builder.rs
@@ -113,18 +113,18 @@ impl<'a> EnumBuilder<'a> {
             .join("");
 
         let doc = match params.len() {
-            1 => doc(params[0].replace("_", " ").to_pascal_case()),
+            1 => doc(params[0].replace('_', " ").to_pascal_case()),
             n => {
                 let mut d: String = params
                     .iter()
                     .enumerate()
                     .filter(|&(i, _)| i != n - 1)
-                    .map(|(_, e)| e.replace("_", " ").to_pascal_case())
+                    .map(|(_, e)| e.replace('_', " ").to_pascal_case())
                     .collect::<Vec<_>>()
                     .join(", ");
 
                 d.push_str(
-                    format!(" and {}", params[n - 1].replace("_", " ").to_pascal_case()).as_str(),
+                    format!(" and {}", params[n - 1].replace('_', " ").to_pascal_case()).as_str(),
                 );
                 doc(d)
             }

--- a/api_generator/src/generator/code_gen/url/enum_builder.rs
+++ b/api_generator/src/generator/code_gen/url/enum_builder.rs
@@ -181,7 +181,7 @@ impl<'a> EnumBuilder<'a> {
             .iter()
             .map(|&p| {
                 syn::Pat::Ident(
-                    syn::BindingMode::ByRef(syn::Mutability::Immutable),
+                    syn::BindingMode::ByValue(syn::Mutability::Immutable),
                     ident(valid_name(p)),
                     None,
                 )
@@ -282,6 +282,7 @@ impl<'a> EnumBuilder<'a> {
                             syn::NestedMetaItem::MetaItem(syn::MetaItem::Word(ident("Debug"))),
                             syn::NestedMetaItem::MetaItem(syn::MetaItem::Word(ident("Clone"))),
                             syn::NestedMetaItem::MetaItem(syn::MetaItem::Word(ident("PartialEq"))),
+                            syn::NestedMetaItem::MetaItem(syn::MetaItem::Word(ident("Eq"))),
                         ],
                     ),
                 },

--- a/api_generator/src/generator/code_gen/url/enum_builder.rs
+++ b/api_generator/src/generator/code_gen/url/enum_builder.rs
@@ -91,7 +91,7 @@ impl<'a> EnumBuilder<'a> {
                 0 => Self::parts_none(),
                 _ => {
                     self.has_lifetime = true;
-                    Self::parts(&path)
+                    Self::parts(path)
                 }
             };
 
@@ -299,7 +299,7 @@ impl<'a> From<&'a (String, ApiEndpoint)> for EnumBuilder<'a> {
         let endpoint = &value.1;
         let mut builder = EnumBuilder::new(value.0.to_pascal_case().as_ref());
         for path in &endpoint.url.paths {
-            builder = builder.with_path(&path);
+            builder = builder.with_path(path);
         }
 
         builder

--- a/api_generator/src/generator/code_gen/url/url_builder.rs
+++ b/api_generator/src/generator/code_gen/url/url_builder.rs
@@ -170,9 +170,9 @@ impl<'a> UrlBuilder<'a> {
     /// Build the AST for an allocated url from the path literals and params.
     fn build_owned(self) -> syn::Block {
         // collection of let {name}_str = [self.]{name}.[join(",")|to_string()];
-        let let_params_exprs = Self::let_parameters_exprs(&self.path, &self.parts);
+        let let_params_exprs = Self::let_parameters_exprs(&self.path, self.parts);
 
-        let mut let_encoded_params_exprs = Self::let_encoded_exprs(&self.path, &self.parts);
+        let mut let_encoded_params_exprs = Self::let_encoded_exprs(&self.path, self.parts);
 
         let url_ident = ident("p");
         let len_expr = {
@@ -275,7 +275,7 @@ impl<'a> UrlBuilder<'a> {
             .filter_map(|p| match *p {
                 PathPart::Param(p) => {
                     let name = valid_name(p);
-                    let name_ident = ident(&name);
+                    let name_ident = ident(name);
                     let ty = &parts[p].ty;
 
                     // don't generate an assignment expression for strings

--- a/api_generator/src/generator/code_gen/url/url_builder.rs
+++ b/api_generator/src/generator/code_gen/url/url_builder.rs
@@ -405,8 +405,15 @@ impl<'a> UrlBuilder<'a> {
         url.iter()
             .map(|p| match *p {
                 PathPart::Literal(p) => {
-                    let lit = syn::Lit::Str(p.to_string(), syn::StrStyle::Cooked);
-                    syn::Stmt::Semi(Box::new(parse_expr(quote!(#url_ident.push_str(#lit)))))
+                    let push = if p.len() == 1 {
+                        let lit = syn::Lit::Char(p.chars().next().unwrap());
+                        quote!(#url_ident.push(#lit))
+                    } else {
+                        let lit = syn::Lit::Str(p.to_string(), syn::StrStyle::Cooked);
+                        quote!(#url_ident.push_str(#lit))
+                    };
+
+                    syn::Stmt::Semi(Box::new(parse_expr(push)))
                 }
                 PathPart::Param(p) => {
                     let name = format!("encoded_{}", valid_name(p));

--- a/api_generator/src/generator/code_gen/url/url_builder.rs
+++ b/api_generator/src/generator/code_gen/url/url_builder.rs
@@ -420,10 +420,7 @@ impl<'a> UrlBuilder<'a> {
     }
 
     pub fn build(self) -> syn::Expr {
-        let has_params = self.path.iter().any(|p| match *p {
-            PathPart::Param(_) => true,
-            _ => false,
-        });
+        let has_params = self.path.iter().any(|p| matches!(p, PathPart::Param(_)));
 
         if has_params {
             self.build_owned().into_expr()

--- a/api_generator/src/generator/code_gen/url/url_builder.rs
+++ b/api_generator/src/generator/code_gen/url/url_builder.rs
@@ -38,7 +38,7 @@ use serde::{Deserialize, Deserializer};
 use std::{collections::BTreeMap, fmt, iter::Iterator, str};
 
 /// A URL path
-#[derive(Debug, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, PartialEq, Eq, Clone)]
 pub struct PathString(#[serde(deserialize_with = "rooted_path_string")] pub String);
 
 /// Ensure all deserialized paths have a leading `/`
@@ -129,7 +129,7 @@ enum PathParseState {
 }
 
 /// A part of a Path
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum PathPart<'a> {
     Literal(&'a str),
     Param(&'a str),

--- a/api_generator/src/generator/mod.rs
+++ b/api_generator/src/generator/mod.rs
@@ -284,8 +284,7 @@ impl DocumentationUrlString {
 
     fn replace_version_in_url(s: String) -> String {
         match url::Url::parse(&s) {
-            Ok(u) => {
-                let mut u = u;
+            Ok(mut u) => {
                 if u.path().contains("/master") {
                     u.set_path(
                         u.path()
@@ -305,7 +304,7 @@ impl DocumentationUrlString {
                             .as_str(),
                     );
                 }
-                u.into_string()
+                u.to_string()
             }
             Err(_) => s,
         }

--- a/api_generator/src/generator/mod.rs
+++ b/api_generator/src/generator/mod.rs
@@ -41,7 +41,6 @@ use void::Void;
 pub mod code_gen;
 pub mod output;
 
-use itertools::Itertools;
 use output::{merge_file, write_file};
 use std::cmp::Ordering;
 
@@ -710,7 +709,7 @@ where
         .paths
         .iter()
         .map(|p| &p.deprecated)
-        .fold1(|d1, d2| Deprecated::combine(d1, d2))
+        .reduce(Deprecated::combine)
         .unwrap_or(&None);
 
     if let Some(deprecated) = deprecation {

--- a/api_generator/src/generator/mod.rs
+++ b/api_generator/src/generator/mod.rs
@@ -29,7 +29,6 @@ use std::{
     hash::{Hash, Hasher},
     io::Read,
     marker::PhantomData,
-    path::PathBuf,
     str::FromStr,
 };
 
@@ -515,16 +514,13 @@ impl Eq for ApiEnum {}
 /// Generates all client source code from the REST API spec
 pub fn generate(
     branch: &str,
-    download_dir: &PathBuf,
-    generated_dir: &PathBuf,
+    download_dir: &std::path::Path,
+    generated_dir: &std::path::Path,
 ) -> Result<(), failure::Error> {
     // read the Api from file
     let api = read_api(branch, download_dir)?;
 
-    let docs_dir = {
-        let d = download_dir.clone();
-        d.parent().unwrap().join("docs")
-    };
+    let docs_dir = download_dir.parent().unwrap().join("docs");
 
     // generated file tracking lists
     let mut tracker = GeneratedFiles::default();
@@ -588,7 +584,7 @@ pub use bulk::*;
         &mut tracker,
     )?;
 
-    let mut generated = generated_dir.clone();
+    let mut generated = generated_dir.to_path_buf();
     generated.push(GENERATED_TOML);
 
     fs::write(generated, toml::to_string_pretty(&tracker)?)?;
@@ -597,7 +593,7 @@ pub use bulk::*;
 }
 
 /// Reads Api from a directory of REST Api specs
-pub fn read_api(branch: &str, download_dir: &PathBuf) -> Result<Api, failure::Error> {
+pub fn read_api(branch: &str, download_dir: &std::path::Path) -> Result<Api, failure::Error> {
     let paths = fs::read_dir(download_dir)?;
     let mut namespaces = BTreeMap::<String, ApiNamespace>::new();
     let mut enums: HashSet<ApiEnum> = HashSet::new();

--- a/api_generator/src/generator/mod.rs
+++ b/api_generator/src/generator/mod.rs
@@ -314,7 +314,7 @@ impl DocumentationUrlString {
 impl core::ops::Deref for DocumentationUrlString {
     type Target = String;
 
-    fn deref(self: &'_ Self) -> &'_ Self::Target {
+    fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
@@ -475,6 +475,12 @@ impl ApiNamespace {
 
     pub fn endpoints(&self) -> &BTreeMap<String, ApiEndpoint> {
         &self.endpoints
+    }
+}
+
+impl Default for ApiNamespace {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/api_generator/src/generator/mod.rs
+++ b/api_generator/src/generator/mod.rs
@@ -199,7 +199,7 @@ impl Default for TypeKind {
 }
 
 /// Details about a deprecated API url path
-#[derive(Debug, PartialEq, Deserialize, Clone)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Clone)]
 pub struct Deprecated {
     pub version: String,
     pub description: String,
@@ -253,7 +253,7 @@ pub struct Url {
 }
 
 /// Body of an API endpoint
-#[derive(Debug, PartialEq, Deserialize, Clone)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Clone)]
 pub struct Body {
     pub description: Option<String>,
     pub required: Option<bool>,
@@ -271,7 +271,7 @@ where
 }
 
 /// A Documentation URL string
-#[derive(Debug, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, PartialEq, Eq, Clone)]
 pub struct DocumentationUrlString(
     #[serde(deserialize_with = "documentation_url_string")] pub String,
 );
@@ -326,7 +326,7 @@ impl fmt::Display for DocumentationUrlString {
 }
 
 /// Documentation for an API endpoint
-#[derive(Debug, PartialEq, Deserialize, Clone)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Clone)]
 pub struct Documentation {
     pub url: Option<DocumentationUrlString>,
     pub description: Option<String>,

--- a/api_generator/src/generator/mod.rs
+++ b/api_generator/src/generator/mod.rs
@@ -550,7 +550,7 @@ pub fn generate(
         write_file(
             input,
             Some(&docs_file),
-            &generated_dir,
+            generated_dir,
             format!("{}.rs", name).as_str(),
             &mut tracker,
         )?;

--- a/api_generator/src/generator/output.rs
+++ b/api_generator/src/generator/output.rs
@@ -4,18 +4,17 @@ use regex::Regex;
 use std::fs::File;
 use std::io::BufReader;
 use std::io::{BufRead, Write};
-use std::path::Path;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Writes the input to the specified file, preceded by a header comment indicating generated code
 pub fn write_file(
     input: String,
-    docs: Option<&PathBuf>,
-    dir: &PathBuf,
+    docs: Option<&Path>,
+    dir: &Path,
     file_name: &str,
     tracker: &mut GeneratedFiles,
 ) -> Result<(), failure::Error> {
-    let mut path = dir.clone();
+    let mut path = dir.to_path_buf();
     path.push(PathBuf::from_slash(file_name));
 
     let mut file = File::create(&path)?;
@@ -106,7 +105,7 @@ pub fn merge_file(
     file_name: &str,
     tracker: &mut GeneratedFiles,
 ) -> Result<(), failure::Error> {
-    let mut path = dir.to_owned();
+    let mut path = dir.to_path_buf();
     path.push(PathBuf::from_slash(file_name));
 
     let mut in_generated_section = false;

--- a/api_generator/src/rest_spec/mod.rs
+++ b/api_generator/src/rest_spec/mod.rs
@@ -21,10 +21,10 @@ use self::reqwest::header::{HeaderMap, HeaderValue, USER_AGENT};
 use flate2::read::GzDecoder;
 use globset::Glob;
 use reqwest::Response;
-use std::{fs::File, io, path::PathBuf};
+use std::{fs::File, io, path::Path};
 use tar::{Archive, Entry};
 
-pub fn download_specs(branch: &str, download_dir: &PathBuf) -> Result<(), failure::Error> {
+pub fn download_specs(branch: &str, download_dir: &Path) -> Result<(), failure::Error> {
     let url = format!(
         "https://api.github.com/repos/elastic/elasticsearch/tarball/{}",
         branch
@@ -59,11 +59,11 @@ pub fn download_specs(branch: &str, download_dir: &PathBuf) -> Result<(), failur
 }
 
 fn write_spec_file(
-    download_dir: &PathBuf,
+    download_dir: &Path,
     mut entry: Entry<GzDecoder<Response>>,
 ) -> Result<(), failure::Error> {
     let path = entry.path()?;
-    let mut dir = download_dir.clone();
+    let mut dir = download_dir.to_path_buf();
     dir.push(path.file_name().unwrap());
     let mut file = File::create(&dir)?;
     io::copy(&mut entry, &mut file)?;

--- a/opensearch/src/cat.rs
+++ b/opensearch/src/cat.rs
@@ -135,7 +135,7 @@ use crate::{
 use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::{borrow::Cow, time::Duration};
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cat Aliases API"]
 pub enum CatAliasesParts<'b> {
     #[doc = "No parts"]
@@ -148,7 +148,7 @@ impl<'b> CatAliasesParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             CatAliasesParts::None => "/_cat/aliases".into(),
-            CatAliasesParts::Name(ref name) => {
+            CatAliasesParts::Name(name) => {
                 let name_str = name.join(",");
                 let encoded_name: Cow<str> =
                     percent_encode(name_str.as_bytes(), PARTS_ENCODED).into();
@@ -326,7 +326,7 @@ impl<'a, 'b> CatAliases<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cat Allocation API"]
 pub enum CatAllocationParts<'b> {
     #[doc = "No parts"]
@@ -339,7 +339,7 @@ impl<'b> CatAllocationParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             CatAllocationParts::None => "/_cat/allocation".into(),
-            CatAllocationParts::NodeId(ref node_id) => {
+            CatAllocationParts::NodeId(node_id) => {
                 let node_id_str = node_id.join(",");
                 let encoded_node_id: Cow<str> =
                     percent_encode(node_id_str.as_bytes(), PARTS_ENCODED).into();
@@ -525,7 +525,7 @@ impl<'a, 'b> CatAllocation<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cat Count API"]
 pub enum CatCountParts<'b> {
     #[doc = "No parts"]
@@ -538,7 +538,7 @@ impl<'b> CatCountParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             CatCountParts::None => "/_cat/count".into(),
-            CatCountParts::Index(ref index) => {
+            CatCountParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
@@ -697,7 +697,7 @@ impl<'a, 'b> CatCount<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cat Fielddata API"]
 pub enum CatFielddataParts<'b> {
     #[doc = "No parts"]
@@ -710,7 +710,7 @@ impl<'b> CatFielddataParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             CatFielddataParts::None => "/_cat/fielddata".into(),
-            CatFielddataParts::Fields(ref fields) => {
+            CatFielddataParts::Fields(fields) => {
                 let fields_str = fields.join(",");
                 let encoded_fields: Cow<str> =
                     percent_encode(fields_str.as_bytes(), PARTS_ENCODED).into();
@@ -888,7 +888,7 @@ impl<'a, 'b> CatFielddata<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cat Health API"]
 pub enum CatHealthParts {
     #[doc = "No parts"]
@@ -1067,7 +1067,7 @@ impl<'a, 'b> CatHealth<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cat Help API"]
 pub enum CatHelpParts {
     #[doc = "No parts"]
@@ -1200,7 +1200,7 @@ impl<'a, 'b> CatHelp<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cat Indices API"]
 pub enum CatIndicesParts<'b> {
     #[doc = "No parts"]
@@ -1213,7 +1213,7 @@ impl<'b> CatIndicesParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             CatIndicesParts::None => "/_cat/indices".into(),
-            CatIndicesParts::Index(ref index) => {
+            CatIndicesParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
@@ -1445,7 +1445,7 @@ impl<'a, 'b> CatIndices<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cat Master API"]
 pub enum CatMasterParts {
     #[doc = "No parts"]
@@ -1624,7 +1624,7 @@ impl<'a, 'b> CatMaster<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cat Nodeattrs API"]
 pub enum CatNodeattrsParts {
     #[doc = "No parts"]
@@ -1803,7 +1803,7 @@ impl<'a, 'b> CatNodeattrs<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cat Nodes API"]
 pub enum CatNodesParts {
     #[doc = "No parts"]
@@ -2009,7 +2009,7 @@ impl<'a, 'b> CatNodes<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cat Pending Tasks API"]
 pub enum CatPendingTasksParts {
     #[doc = "No parts"]
@@ -2197,7 +2197,7 @@ impl<'a, 'b> CatPendingTasks<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cat Plugins API"]
 pub enum CatPluginsParts {
     #[doc = "No parts"]
@@ -2385,7 +2385,7 @@ impl<'a, 'b> CatPlugins<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cat Recovery API"]
 pub enum CatRecoveryParts<'b> {
     #[doc = "No parts"]
@@ -2398,7 +2398,7 @@ impl<'b> CatRecoveryParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             CatRecoveryParts::None => "/_cat/recovery".into(),
-            CatRecoveryParts::Index(ref index) => {
+            CatRecoveryParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
@@ -2603,7 +2603,7 @@ impl<'a, 'b> CatRecovery<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cat Repositories API"]
 pub enum CatRepositoriesParts {
     #[doc = "No parts"]
@@ -2782,7 +2782,7 @@ impl<'a, 'b> CatRepositories<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cat Segments API"]
 pub enum CatSegmentsParts<'b> {
     #[doc = "No parts"]
@@ -2795,7 +2795,7 @@ impl<'b> CatSegmentsParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             CatSegmentsParts::None => "/_cat/segments".into(),
-            CatSegmentsParts::Index(ref index) => {
+            CatSegmentsParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
@@ -2963,7 +2963,7 @@ impl<'a, 'b> CatSegments<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cat Shards API"]
 pub enum CatShardsParts<'b> {
     #[doc = "No parts"]
@@ -2976,7 +2976,7 @@ impl<'b> CatShardsParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             CatShardsParts::None => "/_cat/shards".into(),
-            CatShardsParts::Index(ref index) => {
+            CatShardsParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
@@ -3171,7 +3171,7 @@ impl<'a, 'b> CatShards<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cat Snapshots API"]
 pub enum CatSnapshotsParts<'b> {
     #[doc = "No parts"]
@@ -3184,7 +3184,7 @@ impl<'b> CatSnapshotsParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             CatSnapshotsParts::None => "/_cat/snapshots".into(),
-            CatSnapshotsParts::Repository(ref repository) => {
+            CatSnapshotsParts::Repository(repository) => {
                 let repository_str = repository.join(",");
                 let encoded_repository: Cow<str> =
                     percent_encode(repository_str.as_bytes(), PARTS_ENCODED).into();
@@ -3370,7 +3370,7 @@ impl<'a, 'b> CatSnapshots<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cat Tasks API"]
 pub enum CatTasksParts {
     #[doc = "No parts"]
@@ -3578,7 +3578,7 @@ impl<'a, 'b> CatTasks<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cat Templates API"]
 pub enum CatTemplatesParts<'b> {
     #[doc = "No parts"]
@@ -3591,7 +3591,7 @@ impl<'b> CatTemplatesParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             CatTemplatesParts::None => "/_cat/templates".into(),
-            CatTemplatesParts::Name(ref name) => {
+            CatTemplatesParts::Name(name) => {
                 let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(16usize + encoded_name.len());
                 p.push_str("/_cat/templates/");
@@ -3766,7 +3766,7 @@ impl<'a, 'b> CatTemplates<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cat Thread Pool API"]
 pub enum CatThreadPoolParts<'b> {
     #[doc = "No parts"]
@@ -3779,7 +3779,7 @@ impl<'b> CatThreadPoolParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             CatThreadPoolParts::None => "/_cat/thread_pool".into(),
-            CatThreadPoolParts::ThreadPoolPatterns(ref thread_pool_patterns) => {
+            CatThreadPoolParts::ThreadPoolPatterns(thread_pool_patterns) => {
                 let thread_pool_patterns_str = thread_pool_patterns.join(",");
                 let encoded_thread_pool_patterns: Cow<str> =
                     percent_encode(thread_pool_patterns_str.as_bytes(), PARTS_ENCODED).into();

--- a/opensearch/src/cluster.rs
+++ b/opensearch/src/cluster.rs
@@ -45,7 +45,7 @@ use crate::{
 use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::{borrow::Cow, time::Duration};
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cluster Allocation Explain API"]
 pub enum ClusterAllocationExplainParts {
     #[doc = "No parts"]
@@ -203,7 +203,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cluster Delete Component Template API"]
 pub enum ClusterDeleteComponentTemplateParts<'b> {
     #[doc = "Name"]
@@ -213,7 +213,7 @@ impl<'b> ClusterDeleteComponentTemplateParts<'b> {
     #[doc = "Builds a relative URL path to the Cluster Delete Component Template API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            ClusterDeleteComponentTemplateParts::Name(ref name) => {
+            ClusterDeleteComponentTemplateParts::Name(name) => {
                 let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(21usize + encoded_name.len());
                 p.push_str("/_component_template/");
@@ -339,7 +339,7 @@ impl<'a, 'b> ClusterDeleteComponentTemplate<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cluster Delete Voting Config Exclusions API"]
 pub enum ClusterDeleteVotingConfigExclusionsParts {
     #[doc = "No parts"]
@@ -462,7 +462,7 @@ impl<'a, 'b> ClusterDeleteVotingConfigExclusions<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cluster Exists Component Template API"]
 pub enum ClusterExistsComponentTemplateParts<'b> {
     #[doc = "Name"]
@@ -472,7 +472,7 @@ impl<'b> ClusterExistsComponentTemplateParts<'b> {
     #[doc = "Builds a relative URL path to the Cluster Exists Component Template API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            ClusterExistsComponentTemplateParts::Name(ref name) => {
+            ClusterExistsComponentTemplateParts::Name(name) => {
                 let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(21usize + encoded_name.len());
                 p.push_str("/_component_template/");
@@ -598,7 +598,7 @@ impl<'a, 'b> ClusterExistsComponentTemplate<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cluster Get Component Template API"]
 pub enum ClusterGetComponentTemplateParts<'b> {
     #[doc = "No parts"]
@@ -611,7 +611,7 @@ impl<'b> ClusterGetComponentTemplateParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             ClusterGetComponentTemplateParts::None => "/_component_template".into(),
-            ClusterGetComponentTemplateParts::Name(ref name) => {
+            ClusterGetComponentTemplateParts::Name(name) => {
                 let name_str = name.join(",");
                 let encoded_name: Cow<str> =
                     percent_encode(name_str.as_bytes(), PARTS_ENCODED).into();
@@ -739,7 +739,7 @@ impl<'a, 'b> ClusterGetComponentTemplate<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cluster Get Settings API"]
 pub enum ClusterGetSettingsParts {
     #[doc = "No parts"]
@@ -887,7 +887,7 @@ impl<'a, 'b> ClusterGetSettings<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cluster Health API"]
 pub enum ClusterHealthParts<'b> {
     #[doc = "No parts"]
@@ -900,7 +900,7 @@ impl<'b> ClusterHealthParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             ClusterHealthParts::None => "/_cluster/health".into(),
-            ClusterHealthParts::Index(ref index) => {
+            ClusterHealthParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
@@ -1113,7 +1113,7 @@ impl<'a, 'b> ClusterHealth<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cluster Pending Tasks API"]
 pub enum ClusterPendingTasksParts {
     #[doc = "No parts"]
@@ -1243,7 +1243,7 @@ impl<'a, 'b> ClusterPendingTasks<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cluster Post Voting Config Exclusions API"]
 pub enum ClusterPostVotingConfigExclusionsParts {
     #[doc = "No parts"]
@@ -1410,7 +1410,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cluster Put Component Template API"]
 pub enum ClusterPutComponentTemplateParts<'b> {
     #[doc = "Name"]
@@ -1420,7 +1420,7 @@ impl<'b> ClusterPutComponentTemplateParts<'b> {
     #[doc = "Builds a relative URL path to the Cluster Put Component Template API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            ClusterPutComponentTemplateParts::Name(ref name) => {
+            ClusterPutComponentTemplateParts::Name(name) => {
                 let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(21usize + encoded_name.len());
                 p.push_str("/_component_template/");
@@ -1581,7 +1581,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cluster Put Settings API"]
 pub enum ClusterPutSettingsParts {
     #[doc = "No parts"]
@@ -1746,7 +1746,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cluster Remote Info API"]
 pub enum ClusterRemoteInfoParts {
     #[doc = "No parts"]
@@ -1858,7 +1858,7 @@ impl<'a, 'b> ClusterRemoteInfo<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cluster Reroute API"]
 pub enum ClusterRerouteParts {
     #[doc = "No parts"]
@@ -2054,7 +2054,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cluster State API"]
 pub enum ClusterStateParts<'b> {
     #[doc = "No parts"]
@@ -2069,7 +2069,7 @@ impl<'b> ClusterStateParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             ClusterStateParts::None => "/_cluster/state".into(),
-            ClusterStateParts::Metric(ref metric) => {
+            ClusterStateParts::Metric(metric) => {
                 let metric_str = metric.join(",");
                 let encoded_metric: Cow<str> =
                     percent_encode(metric_str.as_bytes(), PARTS_ENCODED).into();
@@ -2078,7 +2078,7 @@ impl<'b> ClusterStateParts<'b> {
                 p.push_str(encoded_metric.as_ref());
                 p.into()
             }
-            ClusterStateParts::MetricIndex(ref metric, ref index) => {
+            ClusterStateParts::MetricIndex(metric, index) => {
                 let metric_str = metric.join(",");
                 let index_str = index.join(",");
                 let encoded_metric: Cow<str> =
@@ -2089,7 +2089,7 @@ impl<'b> ClusterStateParts<'b> {
                     String::with_capacity(17usize + encoded_metric.len() + encoded_index.len());
                 p.push_str("/_cluster/state/");
                 p.push_str(encoded_metric.as_ref());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.into()
             }
@@ -2267,7 +2267,7 @@ impl<'a, 'b> ClusterState<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Cluster Stats API"]
 pub enum ClusterStatsParts<'b> {
     #[doc = "No parts"]
@@ -2280,7 +2280,7 @@ impl<'b> ClusterStatsParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             ClusterStatsParts::None => "/_cluster/stats".into(),
-            ClusterStatsParts::NodeId(ref node_id) => {
+            ClusterStatsParts::NodeId(node_id) => {
                 let node_id_str = node_id.join(",");
                 let encoded_node_id: Cow<str> =
                     percent_encode(node_id_str.as_bytes(), PARTS_ENCODED).into();

--- a/opensearch/src/dangling_indices.rs
+++ b/opensearch/src/dangling_indices.rs
@@ -49,7 +49,7 @@ use crate::{
 use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::{borrow::Cow, time::Duration};
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Dangling Indices Delete Dangling Index API"]
 pub enum DanglingIndicesDeleteDanglingIndexParts<'b> {
     #[doc = "IndexUuid"]
@@ -59,7 +59,7 @@ impl<'b> DanglingIndicesDeleteDanglingIndexParts<'b> {
     #[doc = "Builds a relative URL path to the Dangling Indices Delete Dangling Index API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            DanglingIndicesDeleteDanglingIndexParts::IndexUuid(ref index_uuid) => {
+            DanglingIndicesDeleteDanglingIndexParts::IndexUuid(index_uuid) => {
                 let encoded_index_uuid: Cow<str> =
                     percent_encode(index_uuid.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(11usize + encoded_index_uuid.len());
@@ -198,7 +198,7 @@ impl<'a, 'b> DanglingIndicesDeleteDanglingIndex<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Dangling Indices Import Dangling Index API"]
 pub enum DanglingIndicesImportDanglingIndexParts<'b> {
     #[doc = "IndexUuid"]
@@ -208,7 +208,7 @@ impl<'b> DanglingIndicesImportDanglingIndexParts<'b> {
     #[doc = "Builds a relative URL path to the Dangling Indices Import Dangling Index API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            DanglingIndicesImportDanglingIndexParts::IndexUuid(ref index_uuid) => {
+            DanglingIndicesImportDanglingIndexParts::IndexUuid(index_uuid) => {
                 let encoded_index_uuid: Cow<str> =
                     percent_encode(index_uuid.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(11usize + encoded_index_uuid.len());
@@ -373,7 +373,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Dangling Indices List Dangling Indices API"]
 pub enum DanglingIndicesListDanglingIndicesParts {
     #[doc = "No parts"]

--- a/opensearch/src/error.rs
+++ b/opensearch/src/error.rs
@@ -127,10 +127,7 @@ impl Error {
 
     /// Returns true if the error is related to serialization or deserialization
     pub fn is_json(&self) -> bool {
-        match &self.kind {
-            Kind::Json(_) => true,
-            _ => false,
-        }
+        matches!(self.kind, Kind::Json(_))
     }
 }
 

--- a/opensearch/src/http/mod.rs
+++ b/opensearch/src/http/mod.rs
@@ -42,7 +42,7 @@ pub use reqwest::StatusCode;
 pub use url::Url;
 
 /// Http methods supported by Elasticsearch
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Method {
     /// get
     Get,

--- a/opensearch/src/http/request.rs
+++ b/opensearch/src/http/request.rs
@@ -173,7 +173,7 @@ impl Body for Vec<u8> {
 impl<'a> Body for &'a [u8] {
     fn write(&self, bytes: &mut BytesMut) -> Result<(), Error> {
         bytes.reserve(self.len());
-        bytes.put_slice(*self);
+        bytes.put_slice(self);
         Ok(())
     }
 }
@@ -206,7 +206,7 @@ mod tests {
     fn serialize_into_jsonbody_writes_to_bytes() -> Result<(), failure::Error> {
         let mut bytes = BytesMut::new();
         let body: JsonBody<_> = json!({"foo":"bar","baz":1}).into();
-        let _ = body.write(&mut bytes)?;
+        body.write(&mut bytes)?;
         // NOTE: serde_json writes properties lexicographically
         assert_eq!(b"{\"baz\":1,\"foo\":\"bar\"}", &bytes[..]);
 
@@ -221,7 +221,7 @@ mod tests {
         bodies.push(json!({"item":2}).into());
 
         let body = NdBody(bodies);
-        let _ = body.write(&mut bytes)?;
+        body.write(&mut bytes)?;
         assert_eq!(b"{\"item\":1}\n{\"item\":2}\n", &bytes[..]);
 
         Ok(())
@@ -231,7 +231,7 @@ mod tests {
     fn bytes_body_writes_to_bytes_mut() -> Result<(), failure::Error> {
         let mut bytes_mut = BytesMut::with_capacity(21);
         let bytes = bytes::Bytes::from(&b"{\"foo\":\"bar\",\"baz\":1}"[..]);
-        let _ = bytes.write(&mut bytes_mut)?;
+        bytes.write(&mut bytes_mut)?;
         assert_eq!(&bytes[..], &bytes_mut[..]);
 
         Ok(())
@@ -243,7 +243,7 @@ mod tests {
         let buf = bytes::Bytes::from(&b"{\"foo\":\"bar\",\"baz\":1}"[..]);
 
         let bytes = buf.bytes().expect("bytes always returns Some");
-        let _ = buf.write(&mut bytes_mut)?;
+        buf.write(&mut bytes_mut)?;
         assert_eq!(&buf[..], &bytes_mut[..]);
         assert_eq!(&bytes[..], &bytes_mut[..]);
 
@@ -254,7 +254,7 @@ mod tests {
     fn vec_body_writes_to_bytes_mut() -> Result<(), failure::Error> {
         let mut bytes_mut = BytesMut::with_capacity(21);
         let bytes = b"{\"foo\":\"bar\",\"baz\":1}".to_vec();
-        let _ = bytes.write(&mut bytes_mut)?;
+        bytes.write(&mut bytes_mut)?;
         assert_eq!(&bytes[..], &bytes_mut[..]);
 
         Ok(())
@@ -264,7 +264,7 @@ mod tests {
     fn bytes_slice_body_writes_to_bytes_mut() -> Result<(), failure::Error> {
         let mut bytes_mut = BytesMut::with_capacity(21);
         let bytes: &'static [u8] = b"{\"foo\":\"bar\",\"baz\":1}";
-        let _ = bytes.write(&mut bytes_mut)?;
+        bytes.write(&mut bytes_mut)?;
         assert_eq!(bytes, &bytes_mut[..]);
 
         Ok(())
@@ -274,7 +274,7 @@ mod tests {
     fn string_body_writes_to_bytes_mut() -> Result<(), failure::Error> {
         let mut bytes_mut = BytesMut::with_capacity(21);
         let s = String::from("{\"foo\":\"bar\",\"baz\":1}");
-        let _ = s.write(&mut bytes_mut)?;
+        s.write(&mut bytes_mut)?;
         assert_eq!(s.as_bytes(), &bytes_mut[..]);
 
         Ok(())
@@ -284,7 +284,7 @@ mod tests {
     fn string_slice_body_writes_to_bytes_mut() -> Result<(), failure::Error> {
         let mut bytes_mut = BytesMut::with_capacity(21);
         let s: &'static str = "{\"foo\":\"bar\",\"baz\":1}";
-        let _ = s.write(&mut bytes_mut)?;
+        s.write(&mut bytes_mut)?;
         assert_eq!(s.as_bytes(), &bytes_mut[..]);
 
         Ok(())

--- a/opensearch/src/indices.rs
+++ b/opensearch/src/indices.rs
@@ -44,7 +44,7 @@ use crate::{
 use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::{borrow::Cow, time::Duration};
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Add Block API"]
 pub enum IndicesAddBlockParts<'b> {
     #[doc = "Index and Block"]
@@ -54,7 +54,7 @@ impl<'b> IndicesAddBlockParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Add Block API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            IndicesAddBlockParts::IndexBlock(ref index, ref block) => {
+            IndicesAddBlockParts::IndexBlock(index, block) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
@@ -62,7 +62,7 @@ impl<'b> IndicesAddBlockParts<'b> {
                     percent_encode(block.as_bytes(), PARTS_ENCODED).into();
                 let mut p =
                     String::with_capacity(9usize + encoded_index.len() + encoded_block.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_block/");
                 p.push_str(encoded_block.as_ref());
@@ -243,7 +243,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Analyze API"]
 pub enum IndicesAnalyzeParts<'b> {
     #[doc = "No parts"]
@@ -256,11 +256,11 @@ impl<'b> IndicesAnalyzeParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IndicesAnalyzeParts::None => "/_analyze".into(),
-            IndicesAnalyzeParts::Index(ref index) => {
+            IndicesAnalyzeParts::Index(index) => {
                 let encoded_index: Cow<str> =
                     percent_encode(index.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(10usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_analyze");
                 p.into()
@@ -402,7 +402,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Clear Cache API"]
 pub enum IndicesClearCacheParts<'b> {
     #[doc = "No parts"]
@@ -415,12 +415,12 @@ impl<'b> IndicesClearCacheParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IndicesClearCacheParts::None => "/_cache/clear".into(),
-            IndicesClearCacheParts::Index(ref index) => {
+            IndicesClearCacheParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(14usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_cache/clear");
                 p.into()
@@ -632,7 +632,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Clone API"]
 pub enum IndicesCloneParts<'b> {
     #[doc = "Index and Target"]
@@ -642,14 +642,14 @@ impl<'b> IndicesCloneParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Clone API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            IndicesCloneParts::IndexTarget(ref index, ref target) => {
+            IndicesCloneParts::IndexTarget(index, target) => {
                 let encoded_index: Cow<str> =
                     percent_encode(index.as_bytes(), PARTS_ENCODED).into();
                 let encoded_target: Cow<str> =
                     percent_encode(target.as_bytes(), PARTS_ENCODED).into();
                 let mut p =
                     String::with_capacity(9usize + encoded_index.len() + encoded_target.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_clone/");
                 p.push_str(encoded_target.as_ref());
@@ -809,7 +809,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Close API"]
 pub enum IndicesCloseParts<'b> {
     #[doc = "Index"]
@@ -819,12 +819,12 @@ impl<'b> IndicesCloseParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Close API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            IndicesCloseParts::Index(ref index) => {
+            IndicesCloseParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(8usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_close");
                 p.into()
@@ -1014,7 +1014,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Create API"]
 pub enum IndicesCreateParts<'b> {
     #[doc = "Index"]
@@ -1024,11 +1024,11 @@ impl<'b> IndicesCreateParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Create API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            IndicesCreateParts::Index(ref index) => {
+            IndicesCreateParts::Index(index) => {
                 let encoded_index: Cow<str> =
                     percent_encode(index.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(1usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.into()
             }
@@ -1186,7 +1186,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Delete API"]
 pub enum IndicesDeleteParts<'b> {
     #[doc = "Index"]
@@ -1196,12 +1196,12 @@ impl<'b> IndicesDeleteParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Delete API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            IndicesDeleteParts::Index(ref index) => {
+            IndicesDeleteParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(1usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.into()
             }
@@ -1352,7 +1352,7 @@ impl<'a, 'b> IndicesDelete<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Delete Alias API"]
 pub enum IndicesDeleteAliasParts<'b> {
     #[doc = "Index and Name"]
@@ -1362,7 +1362,7 @@ impl<'b> IndicesDeleteAliasParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Delete Alias API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            IndicesDeleteAliasParts::IndexName(ref index, ref name) => {
+            IndicesDeleteAliasParts::IndexName(index, name) => {
                 let index_str = index.join(",");
                 let name_str = name.join(",");
                 let encoded_index: Cow<str> =
@@ -1371,7 +1371,7 @@ impl<'b> IndicesDeleteAliasParts<'b> {
                     percent_encode(name_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p =
                     String::with_capacity(9usize + encoded_index.len() + encoded_name.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_alias/");
                 p.push_str(encoded_name.as_ref());
@@ -1496,7 +1496,7 @@ impl<'a, 'b> IndicesDeleteAlias<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Delete Data Stream API"]
 pub enum IndicesDeleteDataStreamParts<'b> {
     #[doc = "Name"]
@@ -1506,7 +1506,7 @@ impl<'b> IndicesDeleteDataStreamParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Delete Data Stream API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            IndicesDeleteDataStreamParts::Name(ref name) => {
+            IndicesDeleteDataStreamParts::Name(name) => {
                 let name_str = name.join(",");
                 let encoded_name: Cow<str> =
                     percent_encode(name_str.as_bytes(), PARTS_ENCODED).into();
@@ -1626,7 +1626,7 @@ impl<'a, 'b> IndicesDeleteDataStream<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Delete Index Template API"]
 pub enum IndicesDeleteIndexTemplateParts<'b> {
     #[doc = "Name"]
@@ -1636,7 +1636,7 @@ impl<'b> IndicesDeleteIndexTemplateParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Delete Index Template API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            IndicesDeleteIndexTemplateParts::Name(ref name) => {
+            IndicesDeleteIndexTemplateParts::Name(name) => {
                 let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(17usize + encoded_name.len());
                 p.push_str("/_index_template/");
@@ -1762,7 +1762,7 @@ impl<'a, 'b> IndicesDeleteIndexTemplate<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Delete Template API"]
 pub enum IndicesDeleteTemplateParts<'b> {
     #[doc = "Name"]
@@ -1772,7 +1772,7 @@ impl<'b> IndicesDeleteTemplateParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Delete Template API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            IndicesDeleteTemplateParts::Name(ref name) => {
+            IndicesDeleteTemplateParts::Name(name) => {
                 let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(11usize + encoded_name.len());
                 p.push_str("/_template/");
@@ -1898,7 +1898,7 @@ impl<'a, 'b> IndicesDeleteTemplate<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Exists API"]
 pub enum IndicesExistsParts<'b> {
     #[doc = "Index"]
@@ -1908,12 +1908,12 @@ impl<'b> IndicesExistsParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Exists API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            IndicesExistsParts::Index(ref index) => {
+            IndicesExistsParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(1usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.into()
             }
@@ -2073,7 +2073,7 @@ impl<'a, 'b> IndicesExists<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Exists Alias API"]
 pub enum IndicesExistsAliasParts<'b> {
     #[doc = "Name"]
@@ -2085,7 +2085,7 @@ impl<'b> IndicesExistsAliasParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Exists Alias API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            IndicesExistsAliasParts::Name(ref name) => {
+            IndicesExistsAliasParts::Name(name) => {
                 let name_str = name.join(",");
                 let encoded_name: Cow<str> =
                     percent_encode(name_str.as_bytes(), PARTS_ENCODED).into();
@@ -2094,7 +2094,7 @@ impl<'b> IndicesExistsAliasParts<'b> {
                 p.push_str(encoded_name.as_ref());
                 p.into()
             }
-            IndicesExistsAliasParts::IndexName(ref index, ref name) => {
+            IndicesExistsAliasParts::IndexName(index, name) => {
                 let index_str = index.join(",");
                 let name_str = name.join(",");
                 let encoded_index: Cow<str> =
@@ -2103,7 +2103,7 @@ impl<'b> IndicesExistsAliasParts<'b> {
                     percent_encode(name_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p =
                     String::with_capacity(9usize + encoded_index.len() + encoded_name.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_alias/");
                 p.push_str(encoded_name.as_ref());
@@ -2247,7 +2247,7 @@ impl<'a, 'b> IndicesExistsAlias<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Exists Index Template API"]
 pub enum IndicesExistsIndexTemplateParts<'b> {
     #[doc = "Name"]
@@ -2257,7 +2257,7 @@ impl<'b> IndicesExistsIndexTemplateParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Exists Index Template API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            IndicesExistsIndexTemplateParts::Name(ref name) => {
+            IndicesExistsIndexTemplateParts::Name(name) => {
                 let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(17usize + encoded_name.len());
                 p.push_str("/_index_template/");
@@ -2392,7 +2392,7 @@ impl<'a, 'b> IndicesExistsIndexTemplate<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Exists Template API"]
 pub enum IndicesExistsTemplateParts<'b> {
     #[doc = "Name"]
@@ -2402,7 +2402,7 @@ impl<'b> IndicesExistsTemplateParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Exists Template API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            IndicesExistsTemplateParts::Name(ref name) => {
+            IndicesExistsTemplateParts::Name(name) => {
                 let name_str = name.join(",");
                 let encoded_name: Cow<str> =
                     percent_encode(name_str.as_bytes(), PARTS_ENCODED).into();
@@ -2539,7 +2539,7 @@ impl<'a, 'b> IndicesExistsTemplate<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Flush API"]
 pub enum IndicesFlushParts<'b> {
     #[doc = "No parts"]
@@ -2552,12 +2552,12 @@ impl<'b> IndicesFlushParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IndicesFlushParts::None => "/_flush".into(),
-            IndicesFlushParts::Index(ref index) => {
+            IndicesFlushParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(8usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_flush");
                 p.into()
@@ -2740,7 +2740,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Forcemerge API"]
 pub enum IndicesForcemergeParts<'b> {
     #[doc = "No parts"]
@@ -2753,12 +2753,12 @@ impl<'b> IndicesForcemergeParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IndicesForcemergeParts::None => "/_forcemerge".into(),
-            IndicesForcemergeParts::Index(ref index) => {
+            IndicesForcemergeParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(13usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_forcemerge");
                 p.into()
@@ -2948,7 +2948,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Get API"]
 pub enum IndicesGetParts<'b> {
     #[doc = "Index"]
@@ -2958,12 +2958,12 @@ impl<'b> IndicesGetParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Get API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            IndicesGetParts::Index(ref index) => {
+            IndicesGetParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(1usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.into()
             }
@@ -3132,7 +3132,7 @@ impl<'a, 'b> IndicesGet<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Get Alias API"]
 pub enum IndicesGetAliasParts<'b> {
     #[doc = "No parts"]
@@ -3149,7 +3149,7 @@ impl<'b> IndicesGetAliasParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IndicesGetAliasParts::None => "/_alias".into(),
-            IndicesGetAliasParts::Name(ref name) => {
+            IndicesGetAliasParts::Name(name) => {
                 let name_str = name.join(",");
                 let encoded_name: Cow<str> =
                     percent_encode(name_str.as_bytes(), PARTS_ENCODED).into();
@@ -3158,7 +3158,7 @@ impl<'b> IndicesGetAliasParts<'b> {
                 p.push_str(encoded_name.as_ref());
                 p.into()
             }
-            IndicesGetAliasParts::IndexName(ref index, ref name) => {
+            IndicesGetAliasParts::IndexName(index, name) => {
                 let index_str = index.join(",");
                 let name_str = name.join(",");
                 let encoded_index: Cow<str> =
@@ -3167,18 +3167,18 @@ impl<'b> IndicesGetAliasParts<'b> {
                     percent_encode(name_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p =
                     String::with_capacity(9usize + encoded_index.len() + encoded_name.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_alias/");
                 p.push_str(encoded_name.as_ref());
                 p.into()
             }
-            IndicesGetAliasParts::Index(ref index) => {
+            IndicesGetAliasParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(8usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_alias");
                 p.into()
@@ -3321,7 +3321,7 @@ impl<'a, 'b> IndicesGetAlias<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Get Field Mapping API"]
 pub enum IndicesGetFieldMappingParts<'b> {
     #[doc = "Fields"]
@@ -3333,7 +3333,7 @@ impl<'b> IndicesGetFieldMappingParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Get Field Mapping API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            IndicesGetFieldMappingParts::Fields(ref fields) => {
+            IndicesGetFieldMappingParts::Fields(fields) => {
                 let fields_str = fields.join(",");
                 let encoded_fields: Cow<str> =
                     percent_encode(fields_str.as_bytes(), PARTS_ENCODED).into();
@@ -3342,7 +3342,7 @@ impl<'b> IndicesGetFieldMappingParts<'b> {
                 p.push_str(encoded_fields.as_ref());
                 p.into()
             }
-            IndicesGetFieldMappingParts::IndexFields(ref index, ref fields) => {
+            IndicesGetFieldMappingParts::IndexFields(index, fields) => {
                 let index_str = index.join(",");
                 let fields_str = fields.join(",");
                 let encoded_index: Cow<str> =
@@ -3351,7 +3351,7 @@ impl<'b> IndicesGetFieldMappingParts<'b> {
                     percent_encode(fields_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p =
                     String::with_capacity(17usize + encoded_index.len() + encoded_fields.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_mapping/field/");
                 p.push_str(encoded_fields.as_ref());
@@ -3504,7 +3504,7 @@ impl<'a, 'b> IndicesGetFieldMapping<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Get Index Template API"]
 pub enum IndicesGetIndexTemplateParts<'b> {
     #[doc = "No parts"]
@@ -3517,7 +3517,7 @@ impl<'b> IndicesGetIndexTemplateParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IndicesGetIndexTemplateParts::None => "/_index_template".into(),
-            IndicesGetIndexTemplateParts::Name(ref name) => {
+            IndicesGetIndexTemplateParts::Name(name) => {
                 let name_str = name.join(",");
                 let encoded_name: Cow<str> =
                     percent_encode(name_str.as_bytes(), PARTS_ENCODED).into();
@@ -3654,7 +3654,7 @@ impl<'a, 'b> IndicesGetIndexTemplate<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Get Mapping API"]
 pub enum IndicesGetMappingParts<'b> {
     #[doc = "No parts"]
@@ -3667,12 +3667,12 @@ impl<'b> IndicesGetMappingParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IndicesGetMappingParts::None => "/_mapping".into(),
-            IndicesGetMappingParts::Index(ref index) => {
+            IndicesGetMappingParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(10usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_mapping");
                 p.into()
@@ -3824,7 +3824,7 @@ impl<'a, 'b> IndicesGetMapping<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Get Settings API"]
 pub enum IndicesGetSettingsParts<'b> {
     #[doc = "No parts"]
@@ -3841,17 +3841,17 @@ impl<'b> IndicesGetSettingsParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IndicesGetSettingsParts::None => "/_settings".into(),
-            IndicesGetSettingsParts::Index(ref index) => {
+            IndicesGetSettingsParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(11usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_settings");
                 p.into()
             }
-            IndicesGetSettingsParts::IndexName(ref index, ref name) => {
+            IndicesGetSettingsParts::IndexName(index, name) => {
                 let index_str = index.join(",");
                 let name_str = name.join(",");
                 let encoded_index: Cow<str> =
@@ -3860,13 +3860,13 @@ impl<'b> IndicesGetSettingsParts<'b> {
                     percent_encode(name_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p =
                     String::with_capacity(12usize + encoded_index.len() + encoded_name.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_settings/");
                 p.push_str(encoded_name.as_ref());
                 p.into()
             }
-            IndicesGetSettingsParts::Name(ref name) => {
+            IndicesGetSettingsParts::Name(name) => {
                 let name_str = name.join(",");
                 let encoded_name: Cow<str> =
                     percent_encode(name_str.as_bytes(), PARTS_ENCODED).into();
@@ -4040,7 +4040,7 @@ impl<'a, 'b> IndicesGetSettings<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Get Template API"]
 pub enum IndicesGetTemplateParts<'b> {
     #[doc = "No parts"]
@@ -4053,7 +4053,7 @@ impl<'b> IndicesGetTemplateParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IndicesGetTemplateParts::None => "/_template".into(),
-            IndicesGetTemplateParts::Name(ref name) => {
+            IndicesGetTemplateParts::Name(name) => {
                 let name_str = name.join(",");
                 let encoded_name: Cow<str> =
                     percent_encode(name_str.as_bytes(), PARTS_ENCODED).into();
@@ -4190,7 +4190,7 @@ impl<'a, 'b> IndicesGetTemplate<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Get Upgrade API"]
 pub enum IndicesGetUpgradeParts<'b> {
     #[doc = "No parts"]
@@ -4203,12 +4203,12 @@ impl<'b> IndicesGetUpgradeParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IndicesGetUpgradeParts::None => "/_upgrade".into(),
-            IndicesGetUpgradeParts::Index(ref index) => {
+            IndicesGetUpgradeParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(10usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_upgrade");
                 p.into()
@@ -4342,7 +4342,7 @@ impl<'a, 'b> IndicesGetUpgrade<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Migrate To Data Stream API"]
 pub enum IndicesMigrateToDataStreamParts<'b> {
     #[doc = "Name"]
@@ -4352,7 +4352,7 @@ impl<'b> IndicesMigrateToDataStreamParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Migrate To Data Stream API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            IndicesMigrateToDataStreamParts::Name(ref name) => {
+            IndicesMigrateToDataStreamParts::Name(name) => {
                 let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(23usize + encoded_name.len());
                 p.push_str("/_data_stream/_migrate/");
@@ -4483,7 +4483,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Open API"]
 pub enum IndicesOpenParts<'b> {
     #[doc = "Index"]
@@ -4493,12 +4493,12 @@ impl<'b> IndicesOpenParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Open API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            IndicesOpenParts::Index(ref index) => {
+            IndicesOpenParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(7usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_open");
                 p.into()
@@ -4688,7 +4688,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Promote Data Stream API"]
 pub enum IndicesPromoteDataStreamParts<'b> {
     #[doc = "Name"]
@@ -4698,7 +4698,7 @@ impl<'b> IndicesPromoteDataStreamParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Promote Data Stream API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            IndicesPromoteDataStreamParts::Name(ref name) => {
+            IndicesPromoteDataStreamParts::Name(name) => {
                 let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(23usize + encoded_name.len());
                 p.push_str("/_data_stream/_promote/");
@@ -4829,7 +4829,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Put Alias API"]
 pub enum IndicesPutAliasParts<'b> {
     #[doc = "Index and Name"]
@@ -4839,14 +4839,14 @@ impl<'b> IndicesPutAliasParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Put Alias API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            IndicesPutAliasParts::IndexName(ref index, ref name) => {
+            IndicesPutAliasParts::IndexName(index, name) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
                 let mut p =
                     String::with_capacity(9usize + encoded_index.len() + encoded_name.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_alias/");
                 p.push_str(encoded_name.as_ref());
@@ -4996,7 +4996,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Put Index Template API"]
 pub enum IndicesPutIndexTemplateParts<'b> {
     #[doc = "Name"]
@@ -5006,7 +5006,7 @@ impl<'b> IndicesPutIndexTemplateParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Put Index Template API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            IndicesPutIndexTemplateParts::Name(ref name) => {
+            IndicesPutIndexTemplateParts::Name(name) => {
                 let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(17usize + encoded_name.len());
                 p.push_str("/_index_template/");
@@ -5167,7 +5167,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Put Mapping API"]
 pub enum IndicesPutMappingParts<'b> {
     #[doc = "Index"]
@@ -5177,12 +5177,12 @@ impl<'b> IndicesPutMappingParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Put Mapping API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            IndicesPutMappingParts::Index(ref index) => {
+            IndicesPutMappingParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(10usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_mapping");
                 p.into()
@@ -5372,7 +5372,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Put Settings API"]
 pub enum IndicesPutSettingsParts<'b> {
     #[doc = "No parts"]
@@ -5385,12 +5385,12 @@ impl<'b> IndicesPutSettingsParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IndicesPutSettingsParts::None => "/_settings".into(),
-            IndicesPutSettingsParts::Index(ref index) => {
+            IndicesPutSettingsParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(11usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_settings");
                 p.into()
@@ -5590,7 +5590,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Put Template API"]
 pub enum IndicesPutTemplateParts<'b> {
     #[doc = "Name"]
@@ -5600,7 +5600,7 @@ impl<'b> IndicesPutTemplateParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Put Template API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            IndicesPutTemplateParts::Name(ref name) => {
+            IndicesPutTemplateParts::Name(name) => {
                 let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(11usize + encoded_name.len());
                 p.push_str("/_template/");
@@ -5761,7 +5761,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Recovery API"]
 pub enum IndicesRecoveryParts<'b> {
     #[doc = "No parts"]
@@ -5774,12 +5774,12 @@ impl<'b> IndicesRecoveryParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IndicesRecoveryParts::None => "/_recovery".into(),
-            IndicesRecoveryParts::Index(ref index) => {
+            IndicesRecoveryParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(11usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_recovery");
                 p.into()
@@ -5903,7 +5903,7 @@ impl<'a, 'b> IndicesRecovery<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Refresh API"]
 pub enum IndicesRefreshParts<'b> {
     #[doc = "No parts"]
@@ -5916,12 +5916,12 @@ impl<'b> IndicesRefreshParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IndicesRefreshParts::None => "/_refresh".into(),
-            IndicesRefreshParts::Index(ref index) => {
+            IndicesRefreshParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(10usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_refresh");
                 p.into()
@@ -6084,7 +6084,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Reload Search Analyzers API"]
 pub enum IndicesReloadSearchAnalyzersParts<'b> {
     #[doc = "Index"]
@@ -6094,12 +6094,12 @@ impl<'b> IndicesReloadSearchAnalyzersParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Reload Search Analyzers API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            IndicesReloadSearchAnalyzersParts::Index(ref index) => {
+            IndicesReloadSearchAnalyzersParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(26usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_reload_search_analyzers");
                 p.into()
@@ -6263,7 +6263,7 @@ where
     }
 }
 #[cfg(feature = "experimental-apis")]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Resolve Index API"]
 pub enum IndicesResolveIndexParts<'b> {
     #[doc = "Name"]
@@ -6274,7 +6274,7 @@ impl<'b> IndicesResolveIndexParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Resolve Index API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            IndicesResolveIndexParts::Name(ref name) => {
+            IndicesResolveIndexParts::Name(name) => {
                 let name_str = name.join(",");
                 let encoded_name: Cow<str> =
                     percent_encode(name_str.as_bytes(), PARTS_ENCODED).into();
@@ -6397,7 +6397,7 @@ impl<'a, 'b> IndicesResolveIndex<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Rollover API"]
 pub enum IndicesRolloverParts<'b> {
     #[doc = "Alias"]
@@ -6409,23 +6409,23 @@ impl<'b> IndicesRolloverParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Rollover API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            IndicesRolloverParts::Alias(ref alias) => {
+            IndicesRolloverParts::Alias(alias) => {
                 let encoded_alias: Cow<str> =
                     percent_encode(alias.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(11usize + encoded_alias.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_alias.as_ref());
                 p.push_str("/_rollover");
                 p.into()
             }
-            IndicesRolloverParts::AliasNewIndex(ref alias, ref new_index) => {
+            IndicesRolloverParts::AliasNewIndex(alias, new_index) => {
                 let encoded_alias: Cow<str> =
                     percent_encode(alias.as_bytes(), PARTS_ENCODED).into();
                 let encoded_new_index: Cow<str> =
                     percent_encode(new_index.as_bytes(), PARTS_ENCODED).into();
                 let mut p =
                     String::with_capacity(12usize + encoded_alias.len() + encoded_new_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_alias.as_ref());
                 p.push_str("/_rollover/");
                 p.push_str(encoded_new_index.as_ref());
@@ -6595,7 +6595,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Segments API"]
 pub enum IndicesSegmentsParts<'b> {
     #[doc = "No parts"]
@@ -6608,12 +6608,12 @@ impl<'b> IndicesSegmentsParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IndicesSegmentsParts::None => "/_segments".into(),
-            IndicesSegmentsParts::Index(ref index) => {
+            IndicesSegmentsParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(11usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_segments");
                 p.into()
@@ -6756,7 +6756,7 @@ impl<'a, 'b> IndicesSegments<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Shard Stores API"]
 pub enum IndicesShardStoresParts<'b> {
     #[doc = "No parts"]
@@ -6769,12 +6769,12 @@ impl<'b> IndicesShardStoresParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IndicesShardStoresParts::None => "/_shard_stores".into(),
-            IndicesShardStoresParts::Index(ref index) => {
+            IndicesShardStoresParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(15usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_shard_stores");
                 p.into()
@@ -6918,7 +6918,7 @@ impl<'a, 'b> IndicesShardStores<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Shrink API"]
 pub enum IndicesShrinkParts<'b> {
     #[doc = "Index and Target"]
@@ -6928,14 +6928,14 @@ impl<'b> IndicesShrinkParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Shrink API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            IndicesShrinkParts::IndexTarget(ref index, ref target) => {
+            IndicesShrinkParts::IndexTarget(index, target) => {
                 let encoded_index: Cow<str> =
                     percent_encode(index.as_bytes(), PARTS_ENCODED).into();
                 let encoded_target: Cow<str> =
                     percent_encode(target.as_bytes(), PARTS_ENCODED).into();
                 let mut p =
                     String::with_capacity(10usize + encoded_index.len() + encoded_target.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_shrink/");
                 p.push_str(encoded_target.as_ref());
@@ -7105,7 +7105,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Simulate Index Template API"]
 pub enum IndicesSimulateIndexTemplateParts<'b> {
     #[doc = "Name"]
@@ -7115,7 +7115,7 @@ impl<'b> IndicesSimulateIndexTemplateParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Simulate Index Template API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            IndicesSimulateIndexTemplateParts::Name(ref name) => {
+            IndicesSimulateIndexTemplateParts::Name(name) => {
                 let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(33usize + encoded_name.len());
                 p.push_str("/_index_template/_simulate_index/");
@@ -7276,7 +7276,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Simulate Template API"]
 pub enum IndicesSimulateTemplateParts<'b> {
     #[doc = "No parts"]
@@ -7289,7 +7289,7 @@ impl<'b> IndicesSimulateTemplateParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IndicesSimulateTemplateParts::None => "/_index_template/_simulate".into(),
-            IndicesSimulateTemplateParts::Name(ref name) => {
+            IndicesSimulateTemplateParts::Name(name) => {
                 let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(27usize + encoded_name.len());
                 p.push_str("/_index_template/_simulate/");
@@ -7450,7 +7450,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Split API"]
 pub enum IndicesSplitParts<'b> {
     #[doc = "Index and Target"]
@@ -7460,14 +7460,14 @@ impl<'b> IndicesSplitParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Split API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            IndicesSplitParts::IndexTarget(ref index, ref target) => {
+            IndicesSplitParts::IndexTarget(index, target) => {
                 let encoded_index: Cow<str> =
                     percent_encode(index.as_bytes(), PARTS_ENCODED).into();
                 let encoded_target: Cow<str> =
                     percent_encode(target.as_bytes(), PARTS_ENCODED).into();
                 let mut p =
                     String::with_capacity(9usize + encoded_index.len() + encoded_target.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_split/");
                 p.push_str(encoded_target.as_ref());
@@ -7637,7 +7637,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Stats API"]
 pub enum IndicesStatsParts<'b> {
     #[doc = "No parts"]
@@ -7654,7 +7654,7 @@ impl<'b> IndicesStatsParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IndicesStatsParts::None => "/_stats".into(),
-            IndicesStatsParts::Metric(ref metric) => {
+            IndicesStatsParts::Metric(metric) => {
                 let metric_str = metric.join(",");
                 let encoded_metric: Cow<str> =
                     percent_encode(metric_str.as_bytes(), PARTS_ENCODED).into();
@@ -7663,17 +7663,17 @@ impl<'b> IndicesStatsParts<'b> {
                 p.push_str(encoded_metric.as_ref());
                 p.into()
             }
-            IndicesStatsParts::Index(ref index) => {
+            IndicesStatsParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(8usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_stats");
                 p.into()
             }
-            IndicesStatsParts::IndexMetric(ref index, ref metric) => {
+            IndicesStatsParts::IndexMetric(index, metric) => {
                 let index_str = index.join(",");
                 let metric_str = metric.join(",");
                 let encoded_index: Cow<str> =
@@ -7682,7 +7682,7 @@ impl<'b> IndicesStatsParts<'b> {
                     percent_encode(metric_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p =
                     String::with_capacity(9usize + encoded_index.len() + encoded_metric.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_stats/");
                 p.push_str(encoded_metric.as_ref());
@@ -7885,7 +7885,7 @@ impl<'a, 'b> IndicesStats<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Unfreeze API"]
 pub enum IndicesUnfreezeParts<'b> {
     #[doc = "Index"]
@@ -7895,11 +7895,11 @@ impl<'b> IndicesUnfreezeParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Unfreeze API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            IndicesUnfreezeParts::Index(ref index) => {
+            IndicesUnfreezeParts::Index(index) => {
                 let encoded_index: Cow<str> =
                     percent_encode(index.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(11usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_unfreeze");
                 p.into()
@@ -8089,7 +8089,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Update Aliases API"]
 pub enum IndicesUpdateAliasesParts {
     #[doc = "No parts"]
@@ -8244,7 +8244,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Upgrade API"]
 pub enum IndicesUpgradeParts<'b> {
     #[doc = "No parts"]
@@ -8257,12 +8257,12 @@ impl<'b> IndicesUpgradeParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IndicesUpgradeParts::None => "/_upgrade".into(),
-            IndicesUpgradeParts::Index(ref index) => {
+            IndicesUpgradeParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(10usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_upgrade");
                 p.into()
@@ -8442,7 +8442,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Indices Validate Query API"]
 pub enum IndicesValidateQueryParts<'b> {
     #[doc = "No parts"]
@@ -8455,12 +8455,12 @@ impl<'b> IndicesValidateQueryParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IndicesValidateQueryParts::None => "/_validate/query".into(),
-            IndicesValidateQueryParts::Index(ref index) => {
+            IndicesValidateQueryParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(17usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_validate/query");
                 p.into()

--- a/opensearch/src/ingest.rs
+++ b/opensearch/src/ingest.rs
@@ -56,7 +56,7 @@ use crate::{
 use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::{borrow::Cow, time::Duration};
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Ingest Delete Pipeline API"]
 pub enum IngestDeletePipelineParts<'b> {
     #[doc = "Id"]
@@ -66,7 +66,7 @@ impl<'b> IngestDeletePipelineParts<'b> {
     #[doc = "Builds a relative URL path to the Ingest Delete Pipeline API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            IngestDeletePipelineParts::Id(ref id) => {
+            IngestDeletePipelineParts::Id(id) => {
                 let encoded_id: Cow<str> = percent_encode(id.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(18usize + encoded_id.len());
                 p.push_str("/_ingest/pipeline/");
@@ -192,7 +192,7 @@ impl<'a, 'b> IngestDeletePipeline<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Ingest Get Pipeline API"]
 pub enum IngestGetPipelineParts<'b> {
     #[doc = "No parts"]
@@ -205,7 +205,7 @@ impl<'b> IngestGetPipelineParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IngestGetPipelineParts::None => "/_ingest/pipeline".into(),
-            IngestGetPipelineParts::Id(ref id) => {
+            IngestGetPipelineParts::Id(id) => {
                 let encoded_id: Cow<str> = percent_encode(id.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(18usize + encoded_id.len());
                 p.push_str("/_ingest/pipeline/");
@@ -322,7 +322,7 @@ impl<'a, 'b> IngestGetPipeline<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Ingest Processor Grok API"]
 pub enum IngestProcessorGrokParts {
     #[doc = "No parts"]
@@ -434,7 +434,7 @@ impl<'a, 'b> IngestProcessorGrok<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Ingest Put Pipeline API"]
 pub enum IngestPutPipelineParts<'b> {
     #[doc = "Id"]
@@ -444,7 +444,7 @@ impl<'b> IngestPutPipelineParts<'b> {
     #[doc = "Builds a relative URL path to the Ingest Put Pipeline API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            IngestPutPipelineParts::Id(ref id) => {
+            IngestPutPipelineParts::Id(id) => {
                 let encoded_id: Cow<str> = percent_encode(id.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(18usize + encoded_id.len());
                 p.push_str("/_ingest/pipeline/");
@@ -595,7 +595,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Ingest Simulate API"]
 pub enum IngestSimulateParts<'b> {
     #[doc = "No parts"]
@@ -608,7 +608,7 @@ impl<'b> IngestSimulateParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IngestSimulateParts::None => "/_ingest/pipeline/_simulate".into(),
-            IngestSimulateParts::Id(ref id) => {
+            IngestSimulateParts::Id(id) => {
                 let encoded_id: Cow<str> = percent_encode(id.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(28usize + encoded_id.len());
                 p.push_str("/_ingest/pipeline/");

--- a/opensearch/src/nodes.rs
+++ b/opensearch/src/nodes.rs
@@ -45,7 +45,7 @@ use crate::{
 use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::{borrow::Cow, time::Duration};
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Nodes Hot Threads API"]
 pub enum NodesHotThreadsParts<'b> {
     #[doc = "No parts"]
@@ -58,7 +58,7 @@ impl<'b> NodesHotThreadsParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             NodesHotThreadsParts::None => "/_nodes/hot_threads".into(),
-            NodesHotThreadsParts::NodeId(ref node_id) => {
+            NodesHotThreadsParts::NodeId(node_id) => {
                 let node_id_str = node_id.join(",");
                 let encoded_node_id: Cow<str> =
                     percent_encode(node_id_str.as_bytes(), PARTS_ENCODED).into();
@@ -224,7 +224,7 @@ impl<'a, 'b> NodesHotThreads<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Nodes Info API"]
 pub enum NodesInfoParts<'b> {
     #[doc = "No parts"]
@@ -241,7 +241,7 @@ impl<'b> NodesInfoParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             NodesInfoParts::None => "/_nodes".into(),
-            NodesInfoParts::NodeId(ref node_id) => {
+            NodesInfoParts::NodeId(node_id) => {
                 let node_id_str = node_id.join(",");
                 let encoded_node_id: Cow<str> =
                     percent_encode(node_id_str.as_bytes(), PARTS_ENCODED).into();
@@ -250,7 +250,7 @@ impl<'b> NodesInfoParts<'b> {
                 p.push_str(encoded_node_id.as_ref());
                 p.into()
             }
-            NodesInfoParts::Metric(ref metric) => {
+            NodesInfoParts::Metric(metric) => {
                 let metric_str = metric.join(",");
                 let encoded_metric: Cow<str> =
                     percent_encode(metric_str.as_bytes(), PARTS_ENCODED).into();
@@ -259,7 +259,7 @@ impl<'b> NodesInfoParts<'b> {
                 p.push_str(encoded_metric.as_ref());
                 p.into()
             }
-            NodesInfoParts::NodeIdMetric(ref node_id, ref metric) => {
+            NodesInfoParts::NodeIdMetric(node_id, metric) => {
                 let node_id_str = node_id.join(",");
                 let metric_str = metric.join(",");
                 let encoded_node_id: Cow<str> =
@@ -270,7 +270,7 @@ impl<'b> NodesInfoParts<'b> {
                     String::with_capacity(9usize + encoded_node_id.len() + encoded_metric.len());
                 p.push_str("/_nodes/");
                 p.push_str(encoded_node_id.as_ref());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_metric.as_ref());
                 p.into()
             }
@@ -393,7 +393,7 @@ impl<'a, 'b> NodesInfo<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Nodes Reload Secure Settings API"]
 pub enum NodesReloadSecureSettingsParts<'b> {
     #[doc = "No parts"]
@@ -406,7 +406,7 @@ impl<'b> NodesReloadSecureSettingsParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             NodesReloadSecureSettingsParts::None => "/_nodes/reload_secure_settings".into(),
-            NodesReloadSecureSettingsParts::NodeId(ref node_id) => {
+            NodesReloadSecureSettingsParts::NodeId(node_id) => {
                 let node_id_str = node_id.join(",");
                 let encoded_node_id: Cow<str> =
                     percent_encode(node_id_str.as_bytes(), PARTS_ENCODED).into();
@@ -550,7 +550,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Nodes Stats API"]
 pub enum NodesStatsParts<'b> {
     #[doc = "No parts"]
@@ -571,7 +571,7 @@ impl<'b> NodesStatsParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             NodesStatsParts::None => "/_nodes/stats".into(),
-            NodesStatsParts::NodeId(ref node_id) => {
+            NodesStatsParts::NodeId(node_id) => {
                 let node_id_str = node_id.join(",");
                 let encoded_node_id: Cow<str> =
                     percent_encode(node_id_str.as_bytes(), PARTS_ENCODED).into();
@@ -581,7 +581,7 @@ impl<'b> NodesStatsParts<'b> {
                 p.push_str("/stats");
                 p.into()
             }
-            NodesStatsParts::Metric(ref metric) => {
+            NodesStatsParts::Metric(metric) => {
                 let metric_str = metric.join(",");
                 let encoded_metric: Cow<str> =
                     percent_encode(metric_str.as_bytes(), PARTS_ENCODED).into();
@@ -590,7 +590,7 @@ impl<'b> NodesStatsParts<'b> {
                 p.push_str(encoded_metric.as_ref());
                 p.into()
             }
-            NodesStatsParts::NodeIdMetric(ref node_id, ref metric) => {
+            NodesStatsParts::NodeIdMetric(node_id, metric) => {
                 let node_id_str = node_id.join(",");
                 let metric_str = metric.join(",");
                 let encoded_node_id: Cow<str> =
@@ -605,7 +605,7 @@ impl<'b> NodesStatsParts<'b> {
                 p.push_str(encoded_metric.as_ref());
                 p.into()
             }
-            NodesStatsParts::MetricIndexMetric(ref metric, ref index_metric) => {
+            NodesStatsParts::MetricIndexMetric(metric, index_metric) => {
                 let metric_str = metric.join(",");
                 let index_metric_str = index_metric.join(",");
                 let encoded_metric: Cow<str> =
@@ -617,11 +617,11 @@ impl<'b> NodesStatsParts<'b> {
                 );
                 p.push_str("/_nodes/stats/");
                 p.push_str(encoded_metric.as_ref());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index_metric.as_ref());
                 p.into()
             }
-            NodesStatsParts::NodeIdMetricIndexMetric(ref node_id, ref metric, ref index_metric) => {
+            NodesStatsParts::NodeIdMetricIndexMetric(node_id, metric, index_metric) => {
                 let node_id_str = node_id.join(",");
                 let metric_str = metric.join(",");
                 let index_metric_str = index_metric.join(",");
@@ -641,7 +641,7 @@ impl<'b> NodesStatsParts<'b> {
                 p.push_str(encoded_node_id.as_ref());
                 p.push_str("/stats/");
                 p.push_str(encoded_metric.as_ref());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index_metric.as_ref());
                 p.into()
             }
@@ -822,7 +822,7 @@ impl<'a, 'b> NodesStats<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Nodes Usage API"]
 pub enum NodesUsageParts<'b> {
     #[doc = "No parts"]
@@ -839,7 +839,7 @@ impl<'b> NodesUsageParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             NodesUsageParts::None => "/_nodes/usage".into(),
-            NodesUsageParts::NodeId(ref node_id) => {
+            NodesUsageParts::NodeId(node_id) => {
                 let node_id_str = node_id.join(",");
                 let encoded_node_id: Cow<str> =
                     percent_encode(node_id_str.as_bytes(), PARTS_ENCODED).into();
@@ -849,7 +849,7 @@ impl<'b> NodesUsageParts<'b> {
                 p.push_str("/usage");
                 p.into()
             }
-            NodesUsageParts::Metric(ref metric) => {
+            NodesUsageParts::Metric(metric) => {
                 let metric_str = metric.join(",");
                 let encoded_metric: Cow<str> =
                     percent_encode(metric_str.as_bytes(), PARTS_ENCODED).into();
@@ -858,7 +858,7 @@ impl<'b> NodesUsageParts<'b> {
                 p.push_str(encoded_metric.as_ref());
                 p.into()
             }
-            NodesUsageParts::NodeIdMetric(ref node_id, ref metric) => {
+            NodesUsageParts::NodeIdMetric(node_id, metric) => {
                 let node_id_str = node_id.join(",");
                 let metric_str = metric.join(",");
                 let encoded_node_id: Cow<str> =

--- a/opensearch/src/params.rs
+++ b/opensearch/src/params.rs
@@ -38,7 +38,7 @@ use serde::{de, de::Visitor, Deserializer, Serializer};
 
 use serde::{Deserialize, Serialize};
 #[doc = "The unit in which to display byte values"]
-#[derive(Debug, PartialEq, Deserialize, Serialize, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone, Copy)]
 pub enum Bytes {
     #[serde(rename = "b")]
     B,
@@ -64,7 +64,7 @@ pub enum Bytes {
     Pb,
 }
 #[doc = "What to do when the delete by query hits version conflicts?"]
-#[derive(Debug, PartialEq, Deserialize, Serialize, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone, Copy)]
 pub enum Conflicts {
     #[serde(rename = "abort")]
     Abort,
@@ -72,7 +72,7 @@ pub enum Conflicts {
     Proceed,
 }
 #[doc = "The default operator for query string query (AND or OR)"]
-#[derive(Debug, PartialEq, Deserialize, Serialize, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone, Copy)]
 pub enum DefaultOperator {
     #[serde(rename = "AND")]
     And,
@@ -80,7 +80,7 @@ pub enum DefaultOperator {
     Or,
 }
 #[doc = "Whether to expand wildcard expression to concrete indices that are open, closed or both."]
-#[derive(Debug, PartialEq, Deserialize, Serialize, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone, Copy)]
 pub enum ExpandWildcards {
     #[serde(rename = "open")]
     Open,
@@ -96,7 +96,7 @@ pub enum ExpandWildcards {
 #[doc = "Optional parameter to specify the high level file format"]
 #[doc = "&nbsp;\n# Optional, experimental\nThis requires the `experimental-apis` feature. Can have breaking changes in future\nversions or might even be removed entirely.\n        "]
 #[cfg(feature = "experimental-apis")]
-#[derive(Debug, PartialEq, Deserialize, Serialize, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone, Copy)]
 pub enum Format {
     #[serde(rename = "ndjson")]
     Ndjson,
@@ -110,7 +110,7 @@ pub enum Format {
 #[doc = "Group tasks by nodes or parent/child relationships"]
 #[doc = "&nbsp;\n# Optional, experimental\nThis requires the `experimental-apis` feature. Can have breaking changes in future\nversions or might even be removed entirely.\n        "]
 #[cfg(feature = "experimental-apis")]
-#[derive(Debug, PartialEq, Deserialize, Serialize, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone, Copy)]
 pub enum GroupBy {
     #[serde(rename = "nodes")]
     Nodes,
@@ -120,7 +120,7 @@ pub enum GroupBy {
     None,
 }
 #[doc = "A health status (\"green\", \"yellow\", or \"red\" to filter only indices matching the specified health status"]
-#[derive(Debug, PartialEq, Deserialize, Serialize, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone, Copy)]
 pub enum Health {
     #[serde(rename = "green")]
     Green,
@@ -130,7 +130,7 @@ pub enum Health {
     Red,
 }
 #[doc = "Specify the level of detail for returned information"]
-#[derive(Debug, PartialEq, Deserialize, Serialize, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone, Copy)]
 pub enum Level {
     #[serde(rename = "cluster")]
     Cluster,
@@ -140,7 +140,7 @@ pub enum Level {
     Shards,
 }
 #[doc = "Explicit operation type. Defaults to `index` for requests with an explicit document ID, and to `create`for requests without an explicit document ID"]
-#[derive(Debug, PartialEq, Deserialize, Serialize, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone, Copy)]
 pub enum OpType {
     #[serde(rename = "index")]
     Index,
@@ -148,7 +148,7 @@ pub enum OpType {
     Create,
 }
 #[doc = "If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes."]
-#[derive(Debug, PartialEq, Deserialize, Serialize, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone, Copy)]
 pub enum Refresh {
     #[serde(rename = "true")]
     True,
@@ -158,7 +158,7 @@ pub enum Refresh {
     WaitFor,
 }
 #[doc = "Search operation type"]
-#[derive(Debug, PartialEq, Deserialize, Serialize, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone, Copy)]
 pub enum SearchType {
     #[serde(rename = "query_then_fetch")]
     QueryThenFetch,
@@ -166,7 +166,7 @@ pub enum SearchType {
     DfsQueryThenFetch,
 }
 #[doc = "The multiplier in which to display values"]
-#[derive(Debug, PartialEq, Deserialize, Serialize, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone, Copy)]
 pub enum Size {
     #[serde(rename = "")]
     Unspecified,
@@ -182,7 +182,7 @@ pub enum Size {
     P,
 }
 #[doc = "Specify suggest mode"]
-#[derive(Debug, PartialEq, Deserialize, Serialize, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone, Copy)]
 pub enum SuggestMode {
     #[serde(rename = "missing")]
     Missing,
@@ -192,7 +192,7 @@ pub enum SuggestMode {
     Always,
 }
 #[doc = "The unit in which to display time values"]
-#[derive(Debug, PartialEq, Deserialize, Serialize, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone, Copy)]
 pub enum Time {
     #[serde(rename = "d")]
     D,
@@ -210,7 +210,7 @@ pub enum Time {
     Nanos,
 }
 #[doc = "The type to sample (default: cpu)"]
-#[derive(Debug, PartialEq, Deserialize, Serialize, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone, Copy)]
 pub enum Type {
     #[serde(rename = "cpu")]
     Cpu,
@@ -220,7 +220,7 @@ pub enum Type {
     Block,
 }
 #[doc = "Specific version type"]
-#[derive(Debug, PartialEq, Deserialize, Serialize, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone, Copy)]
 pub enum VersionType {
     #[serde(rename = "internal")]
     Internal,
@@ -232,7 +232,7 @@ pub enum VersionType {
     Force,
 }
 #[doc = "Wait until all currently queued events with the given priority are processed"]
-#[derive(Debug, PartialEq, Deserialize, Serialize, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone, Copy)]
 pub enum WaitForEvents {
     #[serde(rename = "immediate")]
     Immediate,
@@ -248,7 +248,7 @@ pub enum WaitForEvents {
     Languid,
 }
 #[doc = "Wait until cluster is in a specific state"]
-#[derive(Debug, PartialEq, Deserialize, Serialize, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone, Copy)]
 pub enum WaitForStatus {
     #[serde(rename = "green")]
     Green,
@@ -266,7 +266,7 @@ pub enum WaitForStatus {
 ///
 /// When set to `Count` with an integer value `n`, the response accurately tracks the total
 /// hit count that match the query up to `n` documents.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum TrackTotalHits {
     /// Whether to accurately track the number of hits that match the query accurately
@@ -291,7 +291,7 @@ impl From<i64> for TrackTotalHits {
 ///
 /// By default operations return the contents of the `_source` field
 /// unless you have used the `stored_fields` parameter or if the `_source` field is disabled.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum SourceFilter {
     /// Whether `_source` retrieval should be enabled (`true`) or disabled (`false`)
@@ -373,7 +373,7 @@ impl<'a> From<(Vec<&'a str>, Vec<&'a str>)> for SourceFilter {
 /// When set to `Auto`, a task is automatically divided into a reasonable number of slices
 ///
 /// When set to `Count` with an integer value `n`, divides the task into that number of slices
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Slices {
     /// Automatically divide the task into a reasonable number of slices
     Auto,

--- a/opensearch/src/root/bulk.rs
+++ b/opensearch/src/root/bulk.rs
@@ -687,7 +687,7 @@ mod tests {
             .zip(b)
             .map(|(x, y)| x.cmp(y))
             .find(|&ord| ord != Ordering::Equal)
-            .unwrap_or(a.len().cmp(&b.len()))
+            .unwrap_or_else(|| a.len().cmp(&b.len()))
     }
 
     #[test]
@@ -736,7 +736,7 @@ mod tests {
         ops.push(BulkOperation::delete("7").into());
 
         let body = NdBody(ops);
-        let _ = body.write(&mut bytes)?;
+        body.write(&mut bytes)?;
 
         let mut expected = BytesMut::new();
         expected.put_slice(b"{\"index\":{\"_id\":\"1\",\"pipeline\":\"pipeline\",\"if_seq_no\":1,\"if_primary_term\":2,\"routing\":\"routing\",\"version\":3,\"version_type\":\"internal\"}}\n");
@@ -794,7 +794,7 @@ mod tests {
         ops.push(BulkOperation::<()>::delete("4"))?;
 
         let body = NdBody(vec![ops]);
-        let _ = body.write(&mut bytes)?;
+        body.write(&mut bytes)?;
 
         let mut expected = BytesMut::new();
         expected.put_slice(b"{\"index\":{\"_index\":\"index_doc\",\"_id\":\"1\",\"pipeline\":\"pipeline\",\"routing\":\"routing\"}}\n");

--- a/opensearch/src/root/mod.rs
+++ b/opensearch/src/root/mod.rs
@@ -40,7 +40,7 @@ use crate::{
 use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::{borrow::Cow, time::Duration};
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Bulk API"]
 pub enum BulkParts<'b> {
     #[doc = "No parts"]
@@ -53,11 +53,11 @@ impl<'b> BulkParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             BulkParts::None => "/_bulk".into(),
-            BulkParts::Index(ref index) => {
+            BulkParts::Index(index) => {
                 let encoded_index: Cow<str> =
                     percent_encode(index.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(7usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_bulk");
                 p.into()
@@ -290,7 +290,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Clear Scroll API"]
 pub enum ClearScrollParts<'b> {
     #[doc = "No parts"]
@@ -303,7 +303,7 @@ impl<'b> ClearScrollParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             ClearScrollParts::None => "/_search/scroll".into(),
-            ClearScrollParts::ScrollId(ref scroll_id) => {
+            ClearScrollParts::ScrollId(scroll_id) => {
                 let scroll_id_str = scroll_id.join(",");
                 let encoded_scroll_id: Cow<str> =
                     percent_encode(scroll_id_str.as_bytes(), PARTS_ENCODED).into();
@@ -436,7 +436,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Close Point In Time API"]
 pub enum ClosePointInTimeParts {
     #[doc = "No parts"]
@@ -571,7 +571,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Count API"]
 pub enum CountParts<'b> {
     #[doc = "No parts"]
@@ -584,12 +584,12 @@ impl<'b> CountParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             CountParts::None => "/_count".into(),
-            CountParts::Index(ref index) => {
+            CountParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(8usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_count");
                 p.into()
@@ -863,7 +863,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Create API"]
 pub enum CreateParts<'b> {
     #[doc = "Index and Id"]
@@ -873,12 +873,12 @@ impl<'b> CreateParts<'b> {
     #[doc = "Builds a relative URL path to the Create API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            CreateParts::IndexId(ref index, ref id) => {
+            CreateParts::IndexId(index, id) => {
                 let encoded_index: Cow<str> =
                     percent_encode(index.as_bytes(), PARTS_ENCODED).into();
                 let encoded_id: Cow<str> = percent_encode(id.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(10usize + encoded_index.len() + encoded_id.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_create/");
                 p.push_str(encoded_id.as_ref());
@@ -1078,7 +1078,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Delete API"]
 pub enum DeleteParts<'b> {
     #[doc = "Index and Id"]
@@ -1088,12 +1088,12 @@ impl<'b> DeleteParts<'b> {
     #[doc = "Builds a relative URL path to the Delete API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            DeleteParts::IndexId(ref index, ref id) => {
+            DeleteParts::IndexId(index, id) => {
                 let encoded_index: Cow<str> =
                     percent_encode(index.as_bytes(), PARTS_ENCODED).into();
                 let encoded_id: Cow<str> = percent_encode(id.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(7usize + encoded_index.len() + encoded_id.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_doc/");
                 p.push_str(encoded_id.as_ref());
@@ -1272,7 +1272,7 @@ impl<'a, 'b> Delete<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Delete By Query API"]
 pub enum DeleteByQueryParts<'b> {
     #[doc = "Index"]
@@ -1282,12 +1282,12 @@ impl<'b> DeleteByQueryParts<'b> {
     #[doc = "Builds a relative URL path to the Delete By Query API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            DeleteByQueryParts::Index(ref index) => {
+            DeleteByQueryParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(18usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_delete_by_query");
                 p.into()
@@ -1753,7 +1753,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Delete By Query Rethrottle API"]
 pub enum DeleteByQueryRethrottleParts<'b> {
     #[doc = "TaskId"]
@@ -1763,7 +1763,7 @@ impl<'b> DeleteByQueryRethrottleParts<'b> {
     #[doc = "Builds a relative URL path to the Delete By Query Rethrottle API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            DeleteByQueryRethrottleParts::TaskId(ref task_id) => {
+            DeleteByQueryRethrottleParts::TaskId(task_id) => {
                 let encoded_task_id: Cow<str> =
                     percent_encode(task_id.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(30usize + encoded_task_id.len());
@@ -1906,7 +1906,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Delete Script API"]
 pub enum DeleteScriptParts<'b> {
     #[doc = "Id"]
@@ -1916,7 +1916,7 @@ impl<'b> DeleteScriptParts<'b> {
     #[doc = "Builds a relative URL path to the Delete Script API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            DeleteScriptParts::Id(ref id) => {
+            DeleteScriptParts::Id(id) => {
                 let encoded_id: Cow<str> = percent_encode(id.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(10usize + encoded_id.len());
                 p.push_str("/_scripts/");
@@ -2042,7 +2042,7 @@ impl<'a, 'b> DeleteScript<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Exists API"]
 pub enum ExistsParts<'b> {
     #[doc = "Index and Id"]
@@ -2052,12 +2052,12 @@ impl<'b> ExistsParts<'b> {
     #[doc = "Builds a relative URL path to the Exists API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            ExistsParts::IndexId(ref index, ref id) => {
+            ExistsParts::IndexId(index, id) => {
                 let encoded_index: Cow<str> =
                     percent_encode(index.as_bytes(), PARTS_ENCODED).into();
                 let encoded_id: Cow<str> = percent_encode(id.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(7usize + encoded_index.len() + encoded_id.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_doc/");
                 p.push_str(encoded_id.as_ref());
@@ -2258,7 +2258,7 @@ impl<'a, 'b> Exists<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Exists Source API"]
 pub enum ExistsSourceParts<'b> {
     #[doc = "Index and Id"]
@@ -2268,12 +2268,12 @@ impl<'b> ExistsSourceParts<'b> {
     #[doc = "Builds a relative URL path to the Exists Source API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            ExistsSourceParts::IndexId(ref index, ref id) => {
+            ExistsSourceParts::IndexId(index, id) => {
                 let encoded_index: Cow<str> =
                     percent_encode(index.as_bytes(), PARTS_ENCODED).into();
                 let encoded_id: Cow<str> = percent_encode(id.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(10usize + encoded_index.len() + encoded_id.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_source/");
                 p.push_str(encoded_id.as_ref());
@@ -2464,7 +2464,7 @@ impl<'a, 'b> ExistsSource<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Explain API"]
 pub enum ExplainParts<'b> {
     #[doc = "Index and Id"]
@@ -2474,12 +2474,12 @@ impl<'b> ExplainParts<'b> {
     #[doc = "Builds a relative URL path to the Explain API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            ExplainParts::IndexId(ref index, ref id) => {
+            ExplainParts::IndexId(index, id) => {
                 let encoded_index: Cow<str> =
                     percent_encode(index.as_bytes(), PARTS_ENCODED).into();
                 let encoded_id: Cow<str> = percent_encode(id.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(11usize + encoded_index.len() + encoded_id.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_explain/");
                 p.push_str(encoded_id.as_ref());
@@ -2736,7 +2736,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Field Caps API"]
 pub enum FieldCapsParts<'b> {
     #[doc = "No parts"]
@@ -2749,12 +2749,12 @@ impl<'b> FieldCapsParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             FieldCapsParts::None => "/_field_caps".into(),
-            FieldCapsParts::Index(ref index) => {
+            FieldCapsParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(13usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_field_caps");
                 p.into()
@@ -2938,7 +2938,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Get API"]
 pub enum GetParts<'b> {
     #[doc = "Index and Id"]
@@ -2948,12 +2948,12 @@ impl<'b> GetParts<'b> {
     #[doc = "Builds a relative URL path to the Get API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            GetParts::IndexId(ref index, ref id) => {
+            GetParts::IndexId(index, id) => {
                 let encoded_index: Cow<str> =
                     percent_encode(index.as_bytes(), PARTS_ENCODED).into();
                 let encoded_id: Cow<str> = percent_encode(id.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(7usize + encoded_index.len() + encoded_id.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_doc/");
                 p.push_str(encoded_id.as_ref());
@@ -3154,7 +3154,7 @@ impl<'a, 'b> Get<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Get Script API"]
 pub enum GetScriptParts<'b> {
     #[doc = "Id"]
@@ -3164,7 +3164,7 @@ impl<'b> GetScriptParts<'b> {
     #[doc = "Builds a relative URL path to the Get Script API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            GetScriptParts::Id(ref id) => {
+            GetScriptParts::Id(id) => {
                 let encoded_id: Cow<str> = percent_encode(id.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(10usize + encoded_id.len());
                 p.push_str("/_scripts/");
@@ -3282,7 +3282,7 @@ impl<'a, 'b> GetScript<'a, 'b> {
     }
 }
 #[cfg(feature = "experimental-apis")]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Get Script Context API"]
 pub enum GetScriptContextParts {
     #[doc = "No parts"]
@@ -3399,7 +3399,7 @@ impl<'a, 'b> GetScriptContext<'a, 'b> {
     }
 }
 #[cfg(feature = "experimental-apis")]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Get Script Languages API"]
 pub enum GetScriptLanguagesParts {
     #[doc = "No parts"]
@@ -3515,7 +3515,7 @@ impl<'a, 'b> GetScriptLanguages<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Get Source API"]
 pub enum GetSourceParts<'b> {
     #[doc = "Index and Id"]
@@ -3525,12 +3525,12 @@ impl<'b> GetSourceParts<'b> {
     #[doc = "Builds a relative URL path to the Get Source API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            GetSourceParts::IndexId(ref index, ref id) => {
+            GetSourceParts::IndexId(index, id) => {
                 let encoded_index: Cow<str> =
                     percent_encode(index.as_bytes(), PARTS_ENCODED).into();
                 let encoded_id: Cow<str> = percent_encode(id.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(10usize + encoded_index.len() + encoded_id.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_source/");
                 p.push_str(encoded_id.as_ref());
@@ -3721,7 +3721,7 @@ impl<'a, 'b> GetSource<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Index API"]
 pub enum IndexParts<'b> {
     #[doc = "Index and Id"]
@@ -3733,22 +3733,22 @@ impl<'b> IndexParts<'b> {
     #[doc = "Builds a relative URL path to the Index API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            IndexParts::IndexId(ref index, ref id) => {
+            IndexParts::IndexId(index, id) => {
                 let encoded_index: Cow<str> =
                     percent_encode(index.as_bytes(), PARTS_ENCODED).into();
                 let encoded_id: Cow<str> = percent_encode(id.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(7usize + encoded_index.len() + encoded_id.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_doc/");
                 p.push_str(encoded_id.as_ref());
                 p.into()
             }
-            IndexParts::Index(ref index) => {
+            IndexParts::Index(index) => {
                 let encoded_index: Cow<str> =
                     percent_encode(index.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(6usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_doc");
                 p.into()
@@ -3987,7 +3987,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Info API"]
 pub enum InfoParts {
     #[doc = "No parts"]
@@ -4099,7 +4099,7 @@ impl<'a, 'b> Info<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Mget API"]
 pub enum MgetParts<'b> {
     #[doc = "No parts"]
@@ -4112,11 +4112,11 @@ impl<'b> MgetParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MgetParts::None => "/_mget".into(),
-            MgetParts::Index(ref index) => {
+            MgetParts::Index(index) => {
                 let encoded_index: Cow<str> =
                     percent_encode(index.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(7usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_mget");
                 p.into()
@@ -4332,7 +4332,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Msearch API"]
 pub enum MsearchParts<'b> {
     #[doc = "No parts"]
@@ -4345,12 +4345,12 @@ impl<'b> MsearchParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MsearchParts::None => "/_msearch".into(),
-            MsearchParts::Index(ref index) => {
+            MsearchParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(10usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_msearch");
                 p.into()
@@ -4552,7 +4552,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Msearch Template API"]
 pub enum MsearchTemplateParts<'b> {
     #[doc = "No parts"]
@@ -4565,12 +4565,12 @@ impl<'b> MsearchTemplateParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MsearchTemplateParts::None => "/_msearch/template".into(),
-            MsearchTemplateParts::Index(ref index) => {
+            MsearchTemplateParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(19usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_msearch/template");
                 p.into()
@@ -4752,7 +4752,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Mtermvectors API"]
 pub enum MtermvectorsParts<'b> {
     #[doc = "No parts"]
@@ -4765,11 +4765,11 @@ impl<'b> MtermvectorsParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MtermvectorsParts::None => "/_mtermvectors".into(),
-            MtermvectorsParts::Index(ref index) => {
+            MtermvectorsParts::Index(index) => {
                 let encoded_index: Cow<str> =
                     percent_encode(index.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(15usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_mtermvectors");
                 p.into()
@@ -5023,7 +5023,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Open Point In Time API"]
 pub enum OpenPointInTimeParts<'b> {
     #[doc = "No parts"]
@@ -5036,12 +5036,12 @@ impl<'b> OpenPointInTimeParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             OpenPointInTimeParts::None => "/_pit".into(),
-            OpenPointInTimeParts::Index(ref index) => {
+            OpenPointInTimeParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(6usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_pit");
                 p.into()
@@ -5221,7 +5221,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Ping API"]
 pub enum PingParts {
     #[doc = "No parts"]
@@ -5333,7 +5333,7 @@ impl<'a, 'b> Ping<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Put Script API"]
 pub enum PutScriptParts<'b> {
     #[doc = "Id"]
@@ -5345,14 +5345,14 @@ impl<'b> PutScriptParts<'b> {
     #[doc = "Builds a relative URL path to the Put Script API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            PutScriptParts::Id(ref id) => {
+            PutScriptParts::Id(id) => {
                 let encoded_id: Cow<str> = percent_encode(id.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(10usize + encoded_id.len());
                 p.push_str("/_scripts/");
                 p.push_str(encoded_id.as_ref());
                 p.into()
             }
-            PutScriptParts::IdContext(ref id, ref context) => {
+            PutScriptParts::IdContext(id, context) => {
                 let encoded_id: Cow<str> = percent_encode(id.as_bytes(), PARTS_ENCODED).into();
                 let encoded_context: Cow<str> =
                     percent_encode(context.as_bytes(), PARTS_ENCODED).into();
@@ -5360,7 +5360,7 @@ impl<'b> PutScriptParts<'b> {
                     String::with_capacity(11usize + encoded_id.len() + encoded_context.len());
                 p.push_str("/_scripts/");
                 p.push_str(encoded_id.as_ref());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_context.as_ref());
                 p.into()
             }
@@ -5519,7 +5519,7 @@ where
     }
 }
 #[cfg(feature = "experimental-apis")]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Rank Eval API"]
 pub enum RankEvalParts<'b> {
     #[doc = "No parts"]
@@ -5533,12 +5533,12 @@ impl<'b> RankEvalParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             RankEvalParts::None => "/_rank_eval".into(),
-            RankEvalParts::Index(ref index) => {
+            RankEvalParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(12usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_rank_eval");
                 p.into()
@@ -5714,7 +5714,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Reindex API"]
 pub enum ReindexParts {
     #[doc = "No parts"]
@@ -5929,7 +5929,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Reindex Rethrottle API"]
 pub enum ReindexRethrottleParts<'b> {
     #[doc = "TaskId"]
@@ -5939,7 +5939,7 @@ impl<'b> ReindexRethrottleParts<'b> {
     #[doc = "Builds a relative URL path to the Reindex Rethrottle API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            ReindexRethrottleParts::TaskId(ref task_id) => {
+            ReindexRethrottleParts::TaskId(task_id) => {
                 let encoded_task_id: Cow<str> =
                     percent_encode(task_id.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(22usize + encoded_task_id.len());
@@ -6082,7 +6082,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Render Search Template API"]
 pub enum RenderSearchTemplateParts<'b> {
     #[doc = "No parts"]
@@ -6095,7 +6095,7 @@ impl<'b> RenderSearchTemplateParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             RenderSearchTemplateParts::None => "/_render/template".into(),
-            RenderSearchTemplateParts::Id(ref id) => {
+            RenderSearchTemplateParts::Id(id) => {
                 let encoded_id: Cow<str> = percent_encode(id.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(18usize + encoded_id.len());
                 p.push_str("/_render/template/");
@@ -6230,7 +6230,7 @@ where
     }
 }
 #[cfg(feature = "experimental-apis")]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Scripts Painless Execute API"]
 pub enum ScriptsPainlessExecuteParts {
     #[doc = "No parts"]
@@ -6372,7 +6372,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Scroll API"]
 pub enum ScrollParts<'b> {
     #[doc = "No parts"]
@@ -6385,7 +6385,7 @@ impl<'b> ScrollParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             ScrollParts::None => "/_search/scroll".into(),
-            ScrollParts::ScrollId(ref scroll_id) => {
+            ScrollParts::ScrollId(scroll_id) => {
                 let encoded_scroll_id: Cow<str> =
                     percent_encode(scroll_id.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(16usize + encoded_scroll_id.len());
@@ -6550,7 +6550,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Search API"]
 pub enum SearchParts<'b> {
     #[doc = "No parts"]
@@ -6563,12 +6563,12 @@ impl<'b> SearchParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             SearchParts::None => "/_search".into(),
-            SearchParts::Index(ref index) => {
+            SearchParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(9usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_search");
                 p.into()
@@ -7139,7 +7139,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Search Shards API"]
 pub enum SearchShardsParts<'b> {
     #[doc = "No parts"]
@@ -7152,12 +7152,12 @@ impl<'b> SearchShardsParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             SearchShardsParts::None => "/_search_shards".into(),
-            SearchShardsParts::Index(ref index) => {
+            SearchShardsParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(16usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_search_shards");
                 p.into()
@@ -7350,7 +7350,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Search Template API"]
 pub enum SearchTemplateParts<'b> {
     #[doc = "No parts"]
@@ -7363,12 +7363,12 @@ impl<'b> SearchTemplateParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             SearchTemplateParts::None => "/_search/template".into(),
-            SearchTemplateParts::Index(ref index) => {
+            SearchTemplateParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(18usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_search/template");
                 p.into()
@@ -7632,7 +7632,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Termvectors API"]
 pub enum TermvectorsParts<'b> {
     #[doc = "Index and Id"]
@@ -7644,22 +7644,22 @@ impl<'b> TermvectorsParts<'b> {
     #[doc = "Builds a relative URL path to the Termvectors API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            TermvectorsParts::IndexId(ref index, ref id) => {
+            TermvectorsParts::IndexId(index, id) => {
                 let encoded_index: Cow<str> =
                     percent_encode(index.as_bytes(), PARTS_ENCODED).into();
                 let encoded_id: Cow<str> = percent_encode(id.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(15usize + encoded_index.len() + encoded_id.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_termvectors/");
                 p.push_str(encoded_id.as_ref());
                 p.into()
             }
-            TermvectorsParts::Index(ref index) => {
+            TermvectorsParts::Index(index) => {
                 let encoded_index: Cow<str> =
                     percent_encode(index.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(14usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_termvectors");
                 p.into()
@@ -7902,7 +7902,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Update API"]
 pub enum UpdateParts<'b> {
     #[doc = "Index and Id"]
@@ -7912,12 +7912,12 @@ impl<'b> UpdateParts<'b> {
     #[doc = "Builds a relative URL path to the Update API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            UpdateParts::IndexId(ref index, ref id) => {
+            UpdateParts::IndexId(index, id) => {
                 let encoded_index: Cow<str> =
                     percent_encode(index.as_bytes(), PARTS_ENCODED).into();
                 let encoded_id: Cow<str> = percent_encode(id.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(10usize + encoded_index.len() + encoded_id.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_update/");
                 p.push_str(encoded_id.as_ref());
@@ -8170,7 +8170,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Update By Query API"]
 pub enum UpdateByQueryParts<'b> {
     #[doc = "Index"]
@@ -8180,12 +8180,12 @@ impl<'b> UpdateByQueryParts<'b> {
     #[doc = "Builds a relative URL path to the Update By Query API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            UpdateByQueryParts::Index(ref index) => {
+            UpdateByQueryParts::Index(index) => {
                 let index_str = index.join(",");
                 let encoded_index: Cow<str> =
                     percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(18usize + encoded_index.len());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_index.as_ref());
                 p.push_str("/_update_by_query");
                 p.into()
@@ -8671,7 +8671,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Update By Query Rethrottle API"]
 pub enum UpdateByQueryRethrottleParts<'b> {
     #[doc = "TaskId"]
@@ -8681,7 +8681,7 @@ impl<'b> UpdateByQueryRethrottleParts<'b> {
     #[doc = "Builds a relative URL path to the Update By Query Rethrottle API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            UpdateByQueryRethrottleParts::TaskId(ref task_id) => {
+            UpdateByQueryRethrottleParts::TaskId(task_id) => {
                 let encoded_task_id: Cow<str> =
                     percent_encode(task_id.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(30usize + encoded_task_id.len());

--- a/opensearch/src/snapshot.rs
+++ b/opensearch/src/snapshot.rs
@@ -44,7 +44,7 @@ use crate::{
 use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::{borrow::Cow, time::Duration};
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Snapshot Cleanup Repository API"]
 pub enum SnapshotCleanupRepositoryParts<'b> {
     #[doc = "Repository"]
@@ -54,7 +54,7 @@ impl<'b> SnapshotCleanupRepositoryParts<'b> {
     #[doc = "Builds a relative URL path to the Snapshot Cleanup Repository API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            SnapshotCleanupRepositoryParts::Repository(ref repository) => {
+            SnapshotCleanupRepositoryParts::Repository(repository) => {
                 let encoded_repository: Cow<str> =
                     percent_encode(repository.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(20usize + encoded_repository.len());
@@ -207,7 +207,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Snapshot Clone API"]
 pub enum SnapshotCloneParts<'b> {
     #[doc = "Repository, Snapshot and TargetSnapshot"]
@@ -218,9 +218,9 @@ impl<'b> SnapshotCloneParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             SnapshotCloneParts::RepositorySnapshotTargetSnapshot(
-                ref repository,
-                ref snapshot,
-                ref target_snapshot,
+                repository,
+                snapshot,
+                target_snapshot,
             ) => {
                 let encoded_repository: Cow<str> =
                     percent_encode(repository.as_bytes(), PARTS_ENCODED).into();
@@ -236,7 +236,7 @@ impl<'b> SnapshotCloneParts<'b> {
                 );
                 p.push_str("/_snapshot/");
                 p.push_str(encoded_repository.as_ref());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_snapshot.as_ref());
                 p.push_str("/_clone/");
                 p.push_str(encoded_target_snapshot.as_ref());
@@ -376,7 +376,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Snapshot Create API"]
 pub enum SnapshotCreateParts<'b> {
     #[doc = "Repository and Snapshot"]
@@ -386,7 +386,7 @@ impl<'b> SnapshotCreateParts<'b> {
     #[doc = "Builds a relative URL path to the Snapshot Create API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            SnapshotCreateParts::RepositorySnapshot(ref repository, ref snapshot) => {
+            SnapshotCreateParts::RepositorySnapshot(repository, snapshot) => {
                 let encoded_repository: Cow<str> =
                     percent_encode(repository.as_bytes(), PARTS_ENCODED).into();
                 let encoded_snapshot: Cow<str> =
@@ -396,7 +396,7 @@ impl<'b> SnapshotCreateParts<'b> {
                 );
                 p.push_str("/_snapshot/");
                 p.push_str(encoded_repository.as_ref());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_snapshot.as_ref());
                 p.into()
             }
@@ -544,7 +544,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Snapshot Create Repository API"]
 pub enum SnapshotCreateRepositoryParts<'b> {
     #[doc = "Repository"]
@@ -554,7 +554,7 @@ impl<'b> SnapshotCreateRepositoryParts<'b> {
     #[doc = "Builds a relative URL path to the Snapshot Create Repository API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            SnapshotCreateRepositoryParts::Repository(ref repository) => {
+            SnapshotCreateRepositoryParts::Repository(repository) => {
                 let encoded_repository: Cow<str> =
                     percent_encode(repository.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(11usize + encoded_repository.len());
@@ -716,7 +716,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Snapshot Delete API"]
 pub enum SnapshotDeleteParts<'b> {
     #[doc = "Repository and Snapshot"]
@@ -726,7 +726,7 @@ impl<'b> SnapshotDeleteParts<'b> {
     #[doc = "Builds a relative URL path to the Snapshot Delete API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            SnapshotDeleteParts::RepositorySnapshot(ref repository, ref snapshot) => {
+            SnapshotDeleteParts::RepositorySnapshot(repository, snapshot) => {
                 let encoded_repository: Cow<str> =
                     percent_encode(repository.as_bytes(), PARTS_ENCODED).into();
                 let encoded_snapshot: Cow<str> =
@@ -736,7 +736,7 @@ impl<'b> SnapshotDeleteParts<'b> {
                 );
                 p.push_str("/_snapshot/");
                 p.push_str(encoded_repository.as_ref());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_snapshot.as_ref());
                 p.into()
             }
@@ -850,7 +850,7 @@ impl<'a, 'b> SnapshotDelete<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Snapshot Delete Repository API"]
 pub enum SnapshotDeleteRepositoryParts<'b> {
     #[doc = "Repository"]
@@ -860,7 +860,7 @@ impl<'b> SnapshotDeleteRepositoryParts<'b> {
     #[doc = "Builds a relative URL path to the Snapshot Delete Repository API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            SnapshotDeleteRepositoryParts::Repository(ref repository) => {
+            SnapshotDeleteRepositoryParts::Repository(repository) => {
                 let repository_str = repository.join(",");
                 let encoded_repository: Cow<str> =
                     percent_encode(repository_str.as_bytes(), PARTS_ENCODED).into();
@@ -988,7 +988,7 @@ impl<'a, 'b> SnapshotDeleteRepository<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Snapshot Get API"]
 pub enum SnapshotGetParts<'b> {
     #[doc = "Repository and Snapshot"]
@@ -998,7 +998,7 @@ impl<'b> SnapshotGetParts<'b> {
     #[doc = "Builds a relative URL path to the Snapshot Get API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            SnapshotGetParts::RepositorySnapshot(ref repository, ref snapshot) => {
+            SnapshotGetParts::RepositorySnapshot(repository, snapshot) => {
                 let snapshot_str = snapshot.join(",");
                 let encoded_repository: Cow<str> =
                     percent_encode(repository.as_bytes(), PARTS_ENCODED).into();
@@ -1009,7 +1009,7 @@ impl<'b> SnapshotGetParts<'b> {
                 );
                 p.push_str("/_snapshot/");
                 p.push_str(encoded_repository.as_ref());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_snapshot.as_ref());
                 p.into()
             }
@@ -1141,7 +1141,7 @@ impl<'a, 'b> SnapshotGet<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Snapshot Get Features API"]
 pub enum SnapshotGetFeaturesParts {
     #[doc = "No parts"]
@@ -1262,7 +1262,7 @@ impl<'a, 'b> SnapshotGetFeatures<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Snapshot Get Repository API"]
 pub enum SnapshotGetRepositoryParts<'b> {
     #[doc = "No parts"]
@@ -1275,7 +1275,7 @@ impl<'b> SnapshotGetRepositoryParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             SnapshotGetRepositoryParts::None => "/_snapshot".into(),
-            SnapshotGetRepositoryParts::Repository(ref repository) => {
+            SnapshotGetRepositoryParts::Repository(repository) => {
                 let repository_str = repository.join(",");
                 let encoded_repository: Cow<str> =
                     percent_encode(repository_str.as_bytes(), PARTS_ENCODED).into();
@@ -1403,7 +1403,7 @@ impl<'a, 'b> SnapshotGetRepository<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Snapshot Restore API"]
 pub enum SnapshotRestoreParts<'b> {
     #[doc = "Repository and Snapshot"]
@@ -1413,7 +1413,7 @@ impl<'b> SnapshotRestoreParts<'b> {
     #[doc = "Builds a relative URL path to the Snapshot Restore API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            SnapshotRestoreParts::RepositorySnapshot(ref repository, ref snapshot) => {
+            SnapshotRestoreParts::RepositorySnapshot(repository, snapshot) => {
                 let encoded_repository: Cow<str> =
                     percent_encode(repository.as_bytes(), PARTS_ENCODED).into();
                 let encoded_snapshot: Cow<str> =
@@ -1423,7 +1423,7 @@ impl<'b> SnapshotRestoreParts<'b> {
                 );
                 p.push_str("/_snapshot/");
                 p.push_str(encoded_repository.as_ref());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_snapshot.as_ref());
                 p.push_str("/_restore");
                 p.into()
@@ -1572,7 +1572,7 @@ where
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Snapshot Status API"]
 pub enum SnapshotStatusParts<'b> {
     #[doc = "No parts"]
@@ -1587,7 +1587,7 @@ impl<'b> SnapshotStatusParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             SnapshotStatusParts::None => "/_snapshot/_status".into(),
-            SnapshotStatusParts::Repository(ref repository) => {
+            SnapshotStatusParts::Repository(repository) => {
                 let encoded_repository: Cow<str> =
                     percent_encode(repository.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(19usize + encoded_repository.len());
@@ -1596,7 +1596,7 @@ impl<'b> SnapshotStatusParts<'b> {
                 p.push_str("/_status");
                 p.into()
             }
-            SnapshotStatusParts::RepositorySnapshot(ref repository, ref snapshot) => {
+            SnapshotStatusParts::RepositorySnapshot(repository, snapshot) => {
                 let snapshot_str = snapshot.join(",");
                 let encoded_repository: Cow<str> =
                     percent_encode(repository.as_bytes(), PARTS_ENCODED).into();
@@ -1607,7 +1607,7 @@ impl<'b> SnapshotStatusParts<'b> {
                 );
                 p.push_str("/_snapshot/");
                 p.push_str(encoded_repository.as_ref());
-                p.push_str("/");
+                p.push('/');
                 p.push_str(encoded_snapshot.as_ref());
                 p.push_str("/_status");
                 p.into()
@@ -1731,7 +1731,7 @@ impl<'a, 'b> SnapshotStatus<'a, 'b> {
         Ok(response)
     }
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Snapshot Verify Repository API"]
 pub enum SnapshotVerifyRepositoryParts<'b> {
     #[doc = "Repository"]
@@ -1741,7 +1741,7 @@ impl<'b> SnapshotVerifyRepositoryParts<'b> {
     #[doc = "Builds a relative URL path to the Snapshot Verify Repository API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            SnapshotVerifyRepositoryParts::Repository(ref repository) => {
+            SnapshotVerifyRepositoryParts::Repository(repository) => {
                 let encoded_repository: Cow<str> =
                     percent_encode(repository.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(19usize + encoded_repository.len());

--- a/opensearch/src/tasks.rs
+++ b/opensearch/src/tasks.rs
@@ -47,7 +47,7 @@ use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::{borrow::Cow, time::Duration};
 #[cfg(feature = "experimental-apis")]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Tasks Cancel API"]
 pub enum TasksCancelParts<'b> {
     #[doc = "No parts"]
@@ -61,7 +61,7 @@ impl<'b> TasksCancelParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             TasksCancelParts::None => "/_tasks/_cancel".into(),
-            TasksCancelParts::TaskId(ref task_id) => {
+            TasksCancelParts::TaskId(task_id) => {
                 let encoded_task_id: Cow<str> =
                     percent_encode(task_id.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(16usize + encoded_task_id.len());
@@ -240,7 +240,7 @@ where
     }
 }
 #[cfg(feature = "experimental-apis")]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Tasks Get API"]
 pub enum TasksGetParts<'b> {
     #[doc = "TaskId"]
@@ -251,7 +251,7 @@ impl<'b> TasksGetParts<'b> {
     #[doc = "Builds a relative URL path to the Tasks Get API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            TasksGetParts::TaskId(ref task_id) => {
+            TasksGetParts::TaskId(task_id) => {
                 let encoded_task_id: Cow<str> =
                     percent_encode(task_id.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(8usize + encoded_task_id.len());
@@ -382,7 +382,7 @@ impl<'a, 'b> TasksGet<'a, 'b> {
     }
 }
 #[cfg(feature = "experimental-apis")]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Tasks List API"]
 pub enum TasksListParts {
     #[doc = "No parts"]

--- a/opensearch/src/text_structure.rs
+++ b/opensearch/src/text_structure.rs
@@ -47,7 +47,7 @@ use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::{borrow::Cow, time::Duration};
 #[cfg(feature = "experimental-apis")]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[doc = "API parts for the Text Structure Find Structure API"]
 pub enum TextStructureFindStructureParts {
     #[doc = "No parts"]

--- a/opensearch/tests/client.rs
+++ b/opensearch/tests/client.rs
@@ -141,7 +141,7 @@ async fn uses_global_request_timeout() {
     let response = client.ping().send().await;
 
     match response {
-        Ok(_) => assert!(false, "Expected timeout error, but response received"),
+        Ok(_) => panic!("Expected timeout error, but response received"),
         Err(e) => assert!(e.is_timeout(), "Expected timeout error, but was {:?}", e),
     }
 }
@@ -164,7 +164,7 @@ async fn uses_call_request_timeout() {
         .await;
 
     match response {
-        Ok(_) => assert!(false, "Expected timeout error, but response received"),
+        Ok(_) => panic!("Expected timeout error, but response received"),
         Err(e) => assert!(e.is_timeout(), "Expected timeout error, but was {:?}", e),
     }
 }
@@ -229,7 +229,7 @@ async fn deprecation_warning_headers() -> Result<(), failure::Error> {
         .await?;
 
     let warnings = response.warning_headers().collect::<Vec<&str>>();
-    assert!(warnings.len() > 0);
+    assert!(!warnings.is_empty());
     assert!(warnings
         .iter()
         .any(|&w| w.contains("Deprecated aggregation order key")));
@@ -288,9 +288,8 @@ async fn search_with_body() -> Result<(), failure::Error> {
         url.join("_search?allow_no_indices=true")?
     };
 
-    match response.content_length() {
-        Some(c) => assert!(c > 0),
-        None => (),
+    if let Some(c) = response.content_length() {
+        assert!(c > 0)
     };
 
     assert_eq!(response.url(), &expected_url);

--- a/opensearch/tests/common/mod.rs
+++ b/opensearch/tests/common/mod.rs
@@ -32,4 +32,4 @@ pub mod client;
 pub mod server;
 
 #[allow(unused)]
-pub static DEFAULT_USER_AGENT: &'static str = concat!("opensearch-rs/", env!("CARGO_PKG_VERSION"));
+pub static DEFAULT_USER_AGENT: &str = concat!("opensearch-rs/", env!("CARGO_PKG_VERSION"));

--- a/opensearch/tests/common/server.rs
+++ b/opensearch/tests/common/server.rs
@@ -78,19 +78,17 @@ where
             .enable_all()
             .build()
             .expect("new rt");
-        let srv = rt.block_on(async move {
-            hyper::Server::bind(&([127, 0, 0, 1], 0).into()).serve(hyper::service::make_service_fn(
-                move |_| {
-                    let func = func.clone();
-                    async move {
-                        Ok::<_, Infallible>(hyper::service::service_fn(move |req| {
-                            let fut = func(req);
-                            async move { Ok::<_, Infallible>(fut.await) }
-                        }))
-                    }
-                },
-            ))
-        });
+        let srv = hyper::Server::bind(&([127, 0, 0, 1], 0).into()).serve(
+            hyper::service::make_service_fn(move |_| {
+                let func = func.clone();
+                async move {
+                    Ok::<_, Infallible>(hyper::service::service_fn(move |req| {
+                        let fut = func(req);
+                        async move { Ok::<_, Infallible>(fut.await) }
+                    }))
+                }
+            }),
+        );
 
         let addr = srv.local_addr();
         let (shutdown_tx, shutdown_rx) = oneshot::channel();

--- a/opensearch/tests/common/server.rs
+++ b/opensearch/tests/common/server.rs
@@ -78,17 +78,21 @@ where
             .enable_all()
             .build()
             .expect("new rt");
-        let srv = hyper::Server::bind(&([127, 0, 0, 1], 0).into()).serve(
-            hyper::service::make_service_fn(move |_| {
-                let func = func.clone();
-                async move {
-                    Ok::<_, Infallible>(hyper::service::service_fn(move |req| {
-                        let fut = func(req);
-                        async move { Ok::<_, Infallible>(fut.await) }
-                    }))
-                }
-            }),
-        );
+
+        let srv = {
+            let _guard = rt.enter();
+            hyper::Server::bind(&([127, 0, 0, 1], 0).into()).serve(hyper::service::make_service_fn(
+                move |_| {
+                    let func = func.clone();
+                    async move {
+                        Ok::<_, Infallible>(hyper::service::service_fn(move |req| {
+                            let fut = func(req);
+                            async move { Ok::<_, Infallible>(fut.await) }
+                        }))
+                    }
+                },
+            ))
+        };
 
         let addr = srv.local_addr();
         let (shutdown_tx, shutdown_rx) = oneshot::channel();

--- a/yaml_test_runner/src/generator.rs
+++ b/yaml_test_runner/src/generator.rs
@@ -523,9 +523,7 @@ fn test_file_path(relative_path: &Path) -> Result<PathBuf, failure::Error> {
     let mut relative = relative_path.to_path_buf();
     relative.set_extension("");
     // directories and files will form the module names so ensure they're valid module names
-    let clean: String = relative
-        .to_string_lossy()
-        .replace(['.', '-'], "_");
+    let clean: String = relative.to_string_lossy().replace(['.', '-'], "_");
 
     relative = PathBuf::from(clean);
 

--- a/yaml_test_runner/src/generator.rs
+++ b/yaml_test_runner/src/generator.rs
@@ -150,7 +150,7 @@ impl<'a> YamlTests<'a> {
             .collect();
 
         quote! {
-            #![allow(unused_imports, unused_variables, dead_code)]
+            #![allow(unused_imports, unused_variables, dead_code, clippy::redundant_clone, clippy::approx_constant)]
             use crate::common::{client, macros};
             use opensearch::*;
             use opensearch::http::{
@@ -319,7 +319,7 @@ impl<'a> YamlTests<'a> {
                         Ok(())
                     }
                 }),
-                Some(quote! { #ident(&client).await?; }),
+                Some(quote! { #ident(client).await?; }),
             )
         } else {
             (None, None)

--- a/yaml_test_runner/src/generator.rs
+++ b/yaml_test_runner/src/generator.rs
@@ -375,7 +375,7 @@ fn cluster_addr() -> String {
 
 pub fn generate_tests_from_yaml(
     api: &Api,
-    suite: &TestSuite,
+    _suite: &TestSuite,
     version: &semver::Version,
     base_download_dir: &Path,
     download_dir: &Path,
@@ -391,7 +391,7 @@ pub fn generate_tests_from_yaml(
             if file_type.is_dir() {
                 generate_tests_from_yaml(
                     api,
-                    suite,
+                    _suite,
                     version,
                     base_download_dir,
                     &entry.path(),
@@ -405,7 +405,7 @@ pub fn generate_tests_from_yaml(
                     continue;
                 }
 
-                let relative_path = path.strip_prefix(&base_download_dir)?;
+                let relative_path = path.strip_prefix(base_download_dir)?;
                 let test_suite = TestSuite::Free;
 
                 info!("Generating: {}", relative_path.display());
@@ -553,7 +553,7 @@ fn write_test_file(
     path = generated_dir.join(path);
     path.set_extension("rs");
 
-    fs::create_dir_all(&path.parent().unwrap())?;
+    fs::create_dir_all(path.parent().unwrap())?;
     let mut file = File::create(&path)?;
     file.write_all(
         r#"/*

--- a/yaml_test_runner/src/generator.rs
+++ b/yaml_test_runner/src/generator.rs
@@ -50,7 +50,7 @@ use url::Url;
 use yaml_rust::{Yaml, YamlLoader};
 
 /// The test suite to compile
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum TestSuite {
     Free,
 }

--- a/yaml_test_runner/src/generator.rs
+++ b/yaml_test_runner/src/generator.rs
@@ -377,9 +377,9 @@ pub fn generate_tests_from_yaml(
     api: &Api,
     suite: &TestSuite,
     version: &semver::Version,
-    base_download_dir: &PathBuf,
-    download_dir: &PathBuf,
-    generated_dir: &PathBuf,
+    base_download_dir: &Path,
+    download_dir: &Path,
+    generated_dir: &Path,
 ) -> Result<(), failure::Error> {
     let url = Url::parse(cluster_addr().as_ref()).unwrap();
     let global_skips = serde_yaml::from_str::<GlobalSkips>(include_str!("../skip.yml"))?;
@@ -479,7 +479,7 @@ pub fn generate_tests_from_yaml(
 }
 
 /// Writes a mod.rs file in each generated directory
-fn write_mod_files(generated_dir: &PathBuf, toplevel: bool) -> Result<(), failure::Error> {
+fn write_mod_files(generated_dir: &Path, toplevel: bool) -> Result<(), failure::Error> {
     if !generated_dir.exists() {
         fs::create_dir(generated_dir)?;
     }
@@ -516,8 +516,7 @@ fn write_mod_files(generated_dir: &PathBuf, toplevel: bool) -> Result<(), failur
         mods.insert(2, "".into());
     }
 
-    let mut path = generated_dir.clone();
-    path.push("mod.rs");
+    let path = generated_dir.join("mod.rs");
     let mut file = File::create(&path)?;
     let generated_mods: String = mods.join("\n");
     file.write_all(generated_mods.as_bytes())?;
@@ -547,7 +546,7 @@ fn test_file_path(relative_path: &Path) -> Result<PathBuf, failure::Error> {
 fn write_test_file(
     test: YamlTests,
     relative_path: &Path,
-    generated_dir: &PathBuf,
+    generated_dir: &Path,
 ) -> Result<(), failure::Error> {
     if test.should_skip_test("*") {
         info!(

--- a/yaml_test_runner/src/generator.rs
+++ b/yaml_test_runner/src/generator.rs
@@ -349,7 +349,7 @@ impl TestFn {
     /// some function descriptions are the same in YAML tests, which would result in
     /// duplicate generated test function names. Deduplicate by appending incrementing number
     pub fn unique_name(&self, seen_names: &mut HashSet<String>) -> String {
-        let mut fn_name = self.name.replace(" ", "_").to_lowercase().to_snake_case();
+        let mut fn_name = self.name.replace(' ', "_").to_lowercase().to_snake_case();
         while !seen_names.insert(fn_name.clone()) {
             lazy_static! {
                 static ref ENDING_DIGITS_REGEX: Regex = Regex::new(r"^(.*?)_(\d*?)$").unwrap();
@@ -529,8 +529,7 @@ fn test_file_path(relative_path: &Path) -> Result<PathBuf, failure::Error> {
     // directories and files will form the module names so ensure they're valid module names
     let clean: String = relative
         .to_string_lossy()
-        .replace(".", "_")
-        .replace("-", "_");
+        .replace(['.', '-'], "_");
 
     relative = PathBuf::from(clean);
 

--- a/yaml_test_runner/src/github.rs
+++ b/yaml_test_runner/src/github.rs
@@ -35,13 +35,12 @@ use reqwest::{
     header::{HeaderMap, HeaderValue, USER_AGENT},
     Response,
 };
-use std::{fs, fs::File, io, path::PathBuf};
+use std::{fs, fs::File, io, path::Path};
 use tar::{Archive, Entry};
 
 /// Downloads the yaml tests if not already downloaded
-pub fn download_test_suites(branch: &str, download_dir: &PathBuf) -> Result<(), failure::Error> {
-    let mut last_downloaded_version = download_dir.clone();
-    last_downloaded_version.push("last_downloaded_version");
+pub fn download_test_suites(branch: &str, download_dir: &Path) -> Result<(), failure::Error> {
+    let mut last_downloaded_version = download_dir.join("last_downloaded_version");
     if last_downloaded_version.exists() {
         let version = fs::read_to_string(&last_downloaded_version)
             .expect("Unable to read last_downloaded_version of yaml tests");
@@ -91,15 +90,14 @@ pub fn download_test_suites(branch: &str, download_dir: &PathBuf) -> Result<(), 
 }
 
 fn write_test_file(
-    download_dir: &PathBuf,
+    download_dir: &Path,
     suite_dir: &str,
     mut entry: Entry<GzDecoder<Response>>,
 ) -> Result<(), failure::Error> {
     let path = entry.path()?;
 
     let mut dir = {
-        let mut dir = download_dir.clone();
-        dir.push(suite_dir);
+        let mut dir = download_dir.join(suite_dir);
         let parent = path.parent().unwrap().file_name().unwrap();
         dir.push(parent);
         dir

--- a/yaml_test_runner/src/github.rs
+++ b/yaml_test_runner/src/github.rs
@@ -40,7 +40,7 @@ use tar::{Archive, Entry};
 
 /// Downloads the yaml tests if not already downloaded
 pub fn download_test_suites(branch: &str, download_dir: &Path) -> Result<(), failure::Error> {
-    let mut last_downloaded_version = download_dir.join("last_downloaded_version");
+    let last_downloaded_version = download_dir.join("last_downloaded_version");
     if last_downloaded_version.exists() {
         let version = fs::read_to_string(&last_downloaded_version)
             .expect("Unable to read last_downloaded_version of yaml tests");

--- a/yaml_test_runner/src/main.rs
+++ b/yaml_test_runner/src/main.rs
@@ -119,7 +119,7 @@ fn main() -> Result<(), failure::Error> {
 
     github::download_test_suites(&branch, &download_dir)?;
 
-    let api = api_generator::generator::read_api(&branch, &rest_specs_dir)?;
+    let api = api_generator::generator::read_api(&branch, rest_specs_dir)?;
 
     // delete everything under the generated_dir except common dir
     if generated_dir.exists() {

--- a/yaml_test_runner/src/main.rs
+++ b/yaml_test_runner/src/main.rs
@@ -43,7 +43,11 @@ extern crate simple_logger;
 use clap::{App, Arg};
 use log::LevelFilter;
 use serde_json::Value;
-use std::{fs, path::PathBuf, process::exit};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::exit,
+};
 
 mod generator;
 mod github;
@@ -83,7 +87,7 @@ fn main() -> Result<(), failure::Error> {
     info!("Using branch {}", &branch);
     info!("Using test_suite {:?}", &suite);
 
-    let rest_specs_dir = PathBuf::from("./api_generator/rest_specs");
+    let rest_specs_dir = Path::new("./api_generator/rest_specs");
 
     if !rest_specs_dir.exists()
         || rest_specs_dir
@@ -98,11 +102,7 @@ fn main() -> Result<(), failure::Error> {
         exit(1);
     }
 
-    let last_downloaded_rest_spec_branch = {
-        let mut p = rest_specs_dir.clone();
-        p.push("last_downloaded_version");
-        p
-    };
+    let last_downloaded_rest_spec_branch = rest_specs_dir.join("last_downloaded_version");
 
     if !last_downloaded_rest_spec_branch.exists() {
         error!(

--- a/yaml_test_runner/src/step/do.rs
+++ b/yaml_test_runner/src/step/do.rs
@@ -318,7 +318,7 @@ impl ApiCall {
         let api_call = endpoint.full_name.as_ref().unwrap();
         let parts = Self::generate_parts(api_call, endpoint, &parts)?;
         let params = Self::generate_params(api, endpoint, &params)?;
-        let function = syn::Ident::from(api_call.replace(".", "()."));
+        let function = syn::Ident::from(api_call.replace('.', "()."));
         let namespace: Option<String> = if api_call.contains('.') {
             let namespaces: Vec<&str> = api_call.splitn(2, '.').collect();
             Some(namespaces[0].to_string())
@@ -658,7 +658,7 @@ impl ApiCall {
     ) -> Result<Option<Tokens>, failure::Error> {
         // TODO: ideally, this should share the logic from EnumBuilder
         let enum_name = {
-            let name = api_call.to_pascal_case().replace(".", "");
+            let name = api_call.to_pascal_case().replace('.', "");
             syn::Ident::from(format!("{}Parts", name))
         };
 

--- a/yaml_test_runner/src/step/do.rs
+++ b/yaml_test_runner/src/step/do.rs
@@ -444,7 +444,7 @@ impl ApiCall {
                                             r#"cannot parse bool from "{}" for param "{}", {}"#,
                                             s,
                                             n,
-                                            e.to_string()
+                                            e
                                         )))
                                     }
                                 },
@@ -457,7 +457,7 @@ impl ApiCall {
                                             r#"cannot parse f64 from "{}" for param "{}", {}"#,
                                             s,
                                             n,
-                                            e.to_string()
+                                            e
                                         )))
                                     }
                                 },
@@ -477,7 +477,7 @@ impl ApiCall {
                                                     r#"cannot parse i32 from "{}" for param "{}", {}"#,
                                                     s,
                                                     n,
-                                                    e.to_string()
+                                                    e
                                                 )))
                                             }
                                         }

--- a/yaml_test_runner/src/step/do.rs
+++ b/yaml_test_runner/src/step/do.rs
@@ -412,9 +412,8 @@ impl ApiCall {
 
                                         match ok_or_accumulate(&idents) {
                                             Ok(_) => {
-                                                let idents = idents
-                                                    .into_iter()
-                                                    .filter_map(Result::ok);
+                                                let idents =
+                                                    idents.into_iter().filter_map(Result::ok);
 
                                                 tokens.append(quote! {
                                                     .#param_ident(&[#(#idents),*])
@@ -442,9 +441,7 @@ impl ApiCall {
                                     Err(e) => {
                                         return Err(failure::err_msg(format!(
                                             r#"cannot parse bool from "{}" for param "{}", {}"#,
-                                            s,
-                                            n,
-                                            e
+                                            s, n, e
                                         )))
                                     }
                                 },
@@ -455,9 +452,7 @@ impl ApiCall {
                                     Err(e) => {
                                         return Err(failure::err_msg(format!(
                                             r#"cannot parse f64 from "{}" for param "{}", {}"#,
-                                            s,
-                                            n,
-                                            e
+                                            s, n, e
                                         )))
                                     }
                                 },
@@ -475,9 +470,7 @@ impl ApiCall {
                                             Err(e) => {
                                                 return Err(failure::err_msg(format!(
                                                     r#"cannot parse i32 from "{}" for param "{}", {}"#,
-                                                    s,
-                                                    n,
-                                                    e
+                                                    s, n, e
                                                 )))
                                             }
                                         }
@@ -666,11 +659,7 @@ impl ApiCall {
         // Also, short circuit for tests where the only parts specified are null
         // e.g. security API test. It seems these should simply omit the value though...
         if parts.is_empty() || parts.iter().all(|(_, v)| v.is_null()) {
-            let mut param_counts = endpoint
-                .url
-                .paths
-                .iter()
-                .map(|p| p.path.params().len());
+            let mut param_counts = endpoint.url.paths.iter().map(|p| p.path.params().len());
 
             // check there's actually a None value
             if !param_counts.any(|c| c == 0) {
@@ -707,9 +696,10 @@ impl ApiCall {
                             return false;
                         }
 
-                        let contains = parts
-                            .iter()
-                            .filter_map(|i| if p.contains(&i.0) { Some(()) } else { None });
+                        let contains =
+                            parts
+                                .iter()
+                                .filter_map(|i| if p.contains(&i.0) { Some(()) } else { None });
                         contains.count() == parts.len()
                     })
                     .collect::<Vec<_>>();
@@ -760,16 +750,14 @@ impl ApiCall {
 
                         match ty.ty {
                             TypeKind::List => {
-                                let values = s
-                                    .split(',')
-                                    .map(|s| {
-                                        if is_set_value {
-                                            let set_value = Self::from_set_value(s);
-                                            quote! { #set_value.as_str().unwrap() }
-                                        } else {
-                                            quote! { #s }
-                                        }
-                                    });
+                                let values = s.split(',').map(|s| {
+                                    if is_set_value {
+                                        let set_value = Self::from_set_value(s);
+                                        quote! { #set_value.as_str().unwrap() }
+                                    } else {
+                                        quote! { #s }
+                                    }
+                                });
                                 Ok(quote! { &[#(#values),*] })
                             }
                             TypeKind::Long => {
@@ -879,13 +867,10 @@ impl ApiCall {
                         json.split(char::is_whitespace).collect::<Vec<_>>()
                     };
 
-                    let values = split
-                        .into_iter()
-                        .filter(|s| !s.is_empty())
-                        .map(|s| {
-                            let ident = syn::Ident::from(s);
-                            quote! { JsonBody::from(json!(#ident)) }
-                        });
+                    let values = split.into_iter().filter(|s| !s.is_empty()).map(|s| {
+                        let ident = syn::Ident::from(s);
+                        quote! { JsonBody::from(json!(#ident)) }
+                    });
                     Ok(Some(quote!(.body(vec![#(#values),*]))))
                 } else {
                     let ident = syn::Ident::from(json);
@@ -901,21 +886,19 @@ impl ApiCall {
 
                 if endpoint.supports_nd_body() {
                     let values: Vec<serde_json::Value> = serde_yaml::from_str(&s)?;
-                    let json = values
-                        .iter()
-                        .map(|value| {
-                            let mut json = serde_json::to_string(&value).unwrap();
-                            if value.is_string() {
-                                json = replace_set(&json);
-                                let ident = syn::Ident::from(json);
-                                quote!(#ident)
-                            } else {
-                                json = replace_set(json);
-                                json = replace_i64(json);
-                                let ident = syn::Ident::from(json);
-                                quote!(JsonBody::from(json!(#ident)))
-                            }
-                        });
+                    let json = values.iter().map(|value| {
+                        let mut json = serde_json::to_string(&value).unwrap();
+                        if value.is_string() {
+                            json = replace_set(&json);
+                            let ident = syn::Ident::from(json);
+                            quote!(#ident)
+                        } else {
+                            json = replace_set(json);
+                            json = replace_i64(json);
+                            let ident = syn::Ident::from(json);
+                            quote!(JsonBody::from(json!(#ident)))
+                        }
+                    });
                     Ok(Some(quote!(.body(vec![ #(#json),* ]))))
                 } else {
                     let value: serde_json::Value = serde_yaml::from_str(&s)?;

--- a/yaml_test_runner/src/step/mod.rs
+++ b/yaml_test_runner/src/step/mod.rs
@@ -173,7 +173,7 @@ impl Expr {
             // some APIs specify the response body as the first part of the path
             // which should be removed.
             // some tests start the json path with a dot, leading to an empty first element
-            if Self::is_string_body(values[0].as_ref()) || values[0] == "" {
+            if Self::is_string_body(values[0].as_ref()) || values[0].is_empty() {
                 values.remove(0);
             }
 

--- a/yaml_test_runner/tests/common/client.rs
+++ b/yaml_test_runner/tests/common/client.rs
@@ -141,7 +141,7 @@ pub async fn delete_snapshots(client: &OpenSearch) -> Result<(), Error> {
         .text()
         .await?;
 
-    if cat_repo_response.len() > 0 {
+    if !cat_repo_response.is_empty() {
         let repositories: Vec<&str> = cat_repo_response.split_terminator('\n').collect();
 
         // Delete snapshots in each repository

--- a/yaml_test_runner/tests/common/macros.rs
+++ b/yaml_test_runner/tests/common/macros.rs
@@ -103,7 +103,7 @@ macro_rules! assert_request_status_code {
     ($status_code:expr) => {{
         let status_code = $status_code.as_u16();
         assert!(
-            status_code >= 400 && status_code < 600,
+            (400..600).contains(&status_code),
             "expected status code in range 400-599 but was {}",
             status_code
         );


### PR DESCRIPTION
### Description
Cleans up the hundreds of clippy lints, these are highly distracting if developing and compiling using `cargo clippy` rather than `cargo check`. The majority are rather simple and minor fixes such as needless borrows.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
