### PR TITLE
Do not run clippy-check if the branch was pushed by dependabot

### DIFF
--- a/.github/workflows/clippy_check.yml
+++ b/.github/workflows/clippy_check.yml
@@ -3,6 +3,7 @@ name: Clippy check
 jobs:
   clippy_check:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
Signed-off-by: Thomas Farr <tsfarr@amazon.com>

### Description
Workflows triggered by dependabot run with a restricted readonly github token, as such it does not have permissions to write the clippy-check annotations, as can be seen here: https://github.com/opensearch-project/opensearch-rs/actions/runs/3093397255/jobs/5005721692
https://github.com/opensearch-project/opensearch-rs/actions/runs/3093397255/jobs/5005721692

Package updates should not introduce clippy lints due to not changing code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
