### PR TITLE
Update base64 requirement from ^0.13 to ^0.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Github workflow for changelog verification ([#89](https://github.com/opensearch-project/opensearch-rs/pull/89))
 
 ### Changed
+- Update base64 dependency from ^0.13 to ^0.20 ([#95](https://github.com/opensearch-project/opensearch-rs/pull/95))
 
 ### Deprecated
 

--- a/opensearch/Cargo.toml
+++ b/opensearch/Cargo.toml
@@ -29,7 +29,7 @@ rustls-tls = ["reqwest/rustls-tls"]
 aws-auth = ["aws-sigv4", "aws-types"]
 
 [dependencies]
-base64 = "^0.13"
+base64 = "^0.20"
 bytes = "^1.0"
 dyn-clone = "~1"
 lazy_static = "1.4"

--- a/opensearch/src/http/transport.rs
+++ b/opensearch/src/http/transport.rs
@@ -414,7 +414,8 @@ impl Transport {
                 Credentials::ApiKey(i, k) => {
                     let mut header_value = b"ApiKey ".to_vec();
                     {
-                        let mut encoder = Base64Encoder::new(&mut header_value, base64::STANDARD);
+                        let mut encoder =
+                            Base64Encoder::from(&mut header_value, &base64::engine::DEFAULT_ENGINE);
                         write!(encoder, "{}:", i).unwrap();
                         write!(encoder, "{}", k).unwrap();
                     }

--- a/yaml_test_runner/Cargo.toml
+++ b/yaml_test_runner/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 opensearch = { path = "../opensearch", features = ["experimental-apis"]}
 api_generator = { path = "./../api_generator" }
 
-base64 = "^0.13"
+base64 = "^0.20"
 clap = "~2"
 failure = "0.1.6"
 itertools = "0.10.0"


### PR DESCRIPTION
### Description
Update base64 requirement from ^0.13 to ^0.20

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
