### PR TITLE
Added support for Amazon OpenSearch Serverless.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Adds Github workflow for changelog verification ([#89](https://github.com/opensearch-project/opensearch-rs/pull/89))
 - Adds Github workflow for unit tests ([#112](https://github.com/opensearch-project/opensearch-rs/pull/112))
+- Adds support for OpenSearch Serverless ([#96](https://github.com/opensearch-project/opensearch-rs/pull/96))
 
 ### Dependencies
 - Bumps `simple_logger` from 2.3.0 to 4.0.0

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -6,7 +6,7 @@
     - [Add a Document to the Index](#add-a-document-to-the-index)
     - [Search for a Document](#search-for-a-document)
     - [Delete the Index](#delete-the-index)
-  - [Amazon OpenSearch Service](#amazon-opensearch-service)
+  - [Amazon OpenSearch and OpenSearch Serverless](#amazon-opensearch-and-opensearch-serverless)
     - [Create a Client](#create-a-client-1)
 
 # User Guide
@@ -103,9 +103,9 @@ client
     .await?;
 ```
 
-## Amazon OpenSearch Service
+## Amazon OpenSearch and OpenSearch Serverless
 
-This library supports [Amazon OpenSearch Service](https://aws.amazon.com/opensearch-service/).
+This library supports [Amazon OpenSearch Service](https://aws.amazon.com/opensearch-service/) and [OpenSearch Serverless](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless.html).
 
 ### Create a Client
 
@@ -113,11 +113,13 @@ Create a client with AWS credentials as follows. Make sure to specify the correc
 
 ```rust
 let url = Url::parse("https://...");
+let service_name = "es"; // use "aoss" for OpenSearch Serverless
 let conn_pool = SingleNodeConnectionPool::new(url?);
 let region_provider = RegionProviderChain::default_provider().or_else("us-east-1");
 let aws_config = aws_config::from_env().region(region_provider).load().await.clone();
 let transport = TransportBuilder::new(conn_pool)
     .auth(aws_config.clone().try_into()?)
+    .service_name(service_name)
     .build()?;
 let client = OpenSearch::new(transport);
 ```

--- a/opensearch/examples/cat_indices.rs
+++ b/opensearch/examples/cat_indices.rs
@@ -65,7 +65,9 @@ fn create_client() -> Result<OpenSearch, Error> {
 
     /// Determines if Fiddler.exe proxy process is running
     fn running_proxy() -> bool {
-        let system = System::new_with_specifics(RefreshKind::new().with_processes(ProcessRefreshKind::default()));
+        let system = System::new_with_specifics(
+            RefreshKind::new().with_processes(ProcessRefreshKind::default()),
+        );
         let has_fiddler = system.processes_by_name("Fiddler").next().is_some();
         has_fiddler
     }

--- a/opensearch/src/lib.rs
+++ b/opensearch/src/lib.rs
@@ -58,7 +58,7 @@
 //! - **experimental-apis**: Enables experimental APIs. Experimental APIs are just that - an experiment. An experimental
 //!   API might have breaking changes in any future version, or it might even be removed entirely. This feature also
 //!   enables `beta-apis`.
-//! - **aws-auth**: Enables authentication with Amazon OpenSearch.
+//! - **aws-auth**: Enables authentication with Amazon OpenSearch and OpenSearch Serverless.
 //!   Performs AWS SigV4 signing using credential types from `aws-types`.
 //!
 //! # Getting started
@@ -327,9 +327,9 @@
 //! # }
 //! ```
 //!
-//! ## Amazon OpenSearch
+//! ## Amazon OpenSearch and OpenSearch Serverless
 //!
-//! For authenticating against an Amazon OpenSearch endpoint using AWS SigV4 request signing,
+//! For authenticating against an Amazon OpenSearch or OpenSearch Serverless endpoint using AWS SigV4 request signing,
 //! you must enable the `aws-auth` feature, then pass the AWS credentials to the [TransportBuilder](http::transport::TransportBuilder).
 //! The easiest way to retrieve AWS credentials in the required format is to use [aws-config](https://docs.rs/aws-config/latest/aws_config/).
 //!
@@ -349,14 +349,15 @@
 //! # use std::convert::TryInto;
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # #[cfg(feature = "aws-auth")] {
 //! let creds = aws_config::load_from_env().await;
-//! let url = Url::parse("https://example.com")?;
+//! let url = Url::parse("https://...")?;
 //! let region_provider = RegionProviderChain::default_provider().or_else("us-east-1");
 //! let aws_config = aws_config::from_env().region(region_provider).load().await.clone();
 //! let conn_pool = SingleNodeConnectionPool::new(url);
-//! # #[cfg(feature = "aws-auth")] {
 //! let transport = TransportBuilder::new(conn_pool)
 //!     .auth(aws_config.clone().try_into()?)
+//!     .service_name("es") // use "aoss" for OpenSearch Serverless
 //!     .build()?;
 //! let client = OpenSearch::new(transport);
 //! # }

--- a/opensearch/tests/auth.rs
+++ b/opensearch/tests/auth.rs
@@ -34,8 +34,6 @@ use common::*;
 use opensearch::auth::Credentials;
 
 use base64::{prelude::BASE64_STANDARD, write::EncoderWriter as Base64Encoder};
-// use std::fs::File;
-// use std::io::Read;
 use std::io::Write;
 
 #[tokio::test]

--- a/opensearch/tests/aws_auth.rs
+++ b/opensearch/tests/aws_auth.rs
@@ -1,0 +1,86 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+#![cfg(feature = "aws-auth")]
+
+pub mod common;
+use common::*;
+use opensearch::OpenSearch;
+use regex::Regex;
+
+use aws_config::SdkConfig;
+use aws_credential_types::provider::SharedCredentialsProvider;
+use aws_credential_types::Credentials;
+use aws_types::region::Region;
+use std::convert::TryInto;
+
+#[tokio::test]
+async fn aws_auth_get() -> Result<(), failure::Error> {
+    let server = server::http(move |req| async move {
+        let authorization_header = req.headers()["authorization"].to_str().unwrap();
+        let re = Regex::new(r"^AWS4-HMAC-SHA256 Credential=id/\d*/us-west-1/custom/aws4_request, SignedHeaders=accept;content-type;host;x-amz-content-sha256;x-amz-date, Signature=[a-f,0-9].*$").unwrap();
+        assert!(
+            re.is_match(authorization_header),
+            "{}",
+            authorization_header
+        );
+        let amz_content_sha256_header = req.headers()["x-amz-content-sha256"].to_str().unwrap();
+        assert_eq!(
+            amz_content_sha256_header,
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        ); // SHA of empty string
+        http::Response::default()
+    });
+
+    let client = create_aws_client(format!("http://{}", server.addr()).as_ref())?;
+    let _response = client.ping().send().await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn aws_auth_post() -> Result<(), failure::Error> {
+    let server = server::http(move |req| async move {
+        let amz_content_sha256_header = req.headers()["x-amz-content-sha256"].to_str().unwrap();
+        assert_eq!(
+            amz_content_sha256_header,
+            "f3a842f988a653a734ebe4e57c45f19293a002241a72f0b3abbff71e4f5297b9"
+        ); // SHA of the JSON
+        http::Response::default()
+    });
+
+    let client = create_aws_client(format!("http://{}", server.addr()).as_ref())?;
+    client
+        .index(opensearch::IndexParts::Index("movies"))
+        .body(serde_json::json!({
+                "title": "Moneyball",
+                "director": "Bennett Miller",
+                "year": 2011
+            }
+        ))
+        .send()
+        .await?;
+
+    Ok(())
+}
+
+fn create_aws_client(addr: &str) -> Result<OpenSearch, failure::Error> {
+    let aws_creds = Credentials::new("id", "secret", None, None, "token");
+    let creds_provider = SharedCredentialsProvider::new(aws_creds);
+    let aws_config = SdkConfig::builder()
+        .credentials_provider(creds_provider)
+        .region(Region::new("us-west-1"))
+        .build();
+    let builder = client::create_builder(addr)
+        .auth(aws_config.clone().try_into()?)
+        .service_name("custom");
+    Ok(client::create(builder))
+}

--- a/opensearch/tests/cert.rs
+++ b/opensearch/tests/cert.rs
@@ -21,7 +21,10 @@
 //!
 //!
 //! DETACH=true .ci/run-opensearch.sh
-#![cfg(all(feature = "_integration", any(feature = "native-tls", feature = "rustls-tls")))]
+#![cfg(all(
+    feature = "_integration",
+    any(feature = "native-tls", feature = "rustls-tls")
+))]
 
 pub mod common;
 use common::*;

--- a/opensearch/tests/common/client.rs
+++ b/opensearch/tests/common/client.rs
@@ -56,7 +56,9 @@ pub fn cluster_addr() -> String {
 
 /// Checks if Fiddler proxy process is running
 fn running_proxy() -> bool {
-    let system = System::new_with_specifics(RefreshKind::new().with_processes(ProcessRefreshKind::default()));
+    let system = System::new_with_specifics(
+        RefreshKind::new().with_processes(ProcessRefreshKind::default()),
+    );
     let has_fiddler = system.processes_by_name("Fiddler").next().is_some();
     has_fiddler
 }

--- a/opensearch/tests/error.rs
+++ b/opensearch/tests/error.rs
@@ -28,7 +28,7 @@
  * GitHub history for details.
  */
 
- #![cfg(feature = "_integration")]
+#![cfg(feature = "_integration")]
 
 pub mod common;
 use common::*;

--- a/yaml_test_runner/Cargo.toml
+++ b/yaml_test_runner/Cargo.toml
@@ -31,7 +31,7 @@ serde_yaml = "0.9"
 serde_json = { version = "~1", features = ["arbitrary_precision"] }
 simple_logger = "4.0.0"
 syn = { version = "~1.0", features = ["full"] }
-sysinfo = "0.26.4"
+sysinfo = "0.26"
 url = "2.1.1"
 yaml-rust = "0.4.3"
 tar = "~0.4"


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

- Lets you configure the service name, defaults to `es` (Managed OpenSearch).
- Always adds a `x-amz-content-sha256` header as per [doc](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-clients.html). Seems to work against AWS Managed OpenSearch too. 

```rust
     let transport = TransportBuilder::new(conn_pool)
         .auth(aws_config.clone().try_into()?)
         .service_name("aoss")
         .build()?;
```

@Xtansia does this look right? I am a rust noob, so no idea if I got the `String` vs. `str` types right here and whether `service_name` is on the right object or whether we can do better. Please tell me what to do + it needs tests & docs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
