### PR TITLE
Disable "Integration with Unreleased OpenSearch (1.x)" job

### DIFF
--- a/.github/workflows/changelog_verifier.yml
+++ b/.github/workflows/changelog_verifier.yml
@@ -15,4 +15,4 @@ jobs:
 
       - uses: dangoslen/changelog-enforcer@v3
         with:
-          skipLabels: "autocut"
+          skipLabels: "skip-changelog, autocut"

--- a/.github/workflows/test-integrations-unreleased.yml
+++ b/.github/workflows/test-integrations-unreleased.yml
@@ -9,10 +9,11 @@ jobs:
       fail-fast: false
       matrix:
         entry:
-          - { opensearch_ref: '1.x' }
           - { opensearch_ref: '2.0' }
           - { opensearch_ref: '2.x' }
           - { opensearch_ref: 'main' }
+        # Unresolved pathological failure, to be re-enabled on resolution: https://github.com/opensearch-project/opensearch-rs/issues/97
+        # - { opensearch_ref: '1.x' }
     steps:
       - name: Checkout OpenSearch
         uses: actions/checkout@v2


### PR DESCRIPTION
### Description
Disables "Integration with Unreleased OpenSearch (1.x)" job to workaround failure described in #97 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
