### PR TITLE
Fix dependabot-changelog-helper handling of Rust dependency updates

### DIFF
--- a/.github/workflows/dependabot_pr.yml
+++ b/.github/workflows/dependabot_pr.yml
@@ -23,7 +23,7 @@ jobs:
           token: ${{ steps.github_app_token.outputs.token }}
 
       - name: Update the changelog
-        uses: dangoslen/dependabot-changelog-helper@v1
+        uses: dangoslen/dependabot-changelog-helper@v2
         with:
           version: 'Unreleased'
 


### PR DESCRIPTION
### Description
Dependabot changelog helper action was failing on our dependabot PRs as the formatting for the titles didn't match the regex used by the action. A fix has been PRd and released https://github.com/dangoslen/dependabot-changelog-helper/pull/113. So updating referenced version here.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
