### PR TITLE
Fix dependabot PR workflow race condition in labels

### DIFF
--- a/.github/workflows/dependabot_pr.yml
+++ b/.github/workflows/dependabot_pr.yml
@@ -1,5 +1,12 @@
 name: Dependabot PR actions
-on: pull_request
+on: 
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
 
 jobs:
   dependabot:


### PR DESCRIPTION
### Description
Fix dependabot PR workflow race condition in labels.
Workflow will trigger on open before label happens, causing changelog action to do nothing, but is then not re-triggered when the labeling happens.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
