### PR TITLE
Bump `aws-*` dependencies from `>= 0.10` to `>= 0.53`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Added
 - Github workflow for changelog verification ([#89](https://github.com/opensearch-project/opensearch-rs/pull/89))
+
 ### Dependencies
 - Bumps `simple_logger` from 2.3.0 to 4.0.0
 - Bumps `serde_with` from ~1 to ~2
+- Bumps `aws-*` from >=0.10 to >=0.53 ([#108](https://github.com/opensearch-project/opensearch-rs/pull/108))
 
 ### Changed
 - Update base64 dependency from ^0.13 to ^0.20 ([#95](https://github.com/opensearch-project/opensearch-rs/pull/95))

--- a/opensearch/Cargo.toml
+++ b/opensearch/Cargo.toml
@@ -26,7 +26,7 @@ native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
 
 # AWS SigV4 Auth support
-aws-auth = ["aws-sigv4", "aws-types"]
+aws-auth = ["aws-credential-types", "aws-sigv4", "aws-types"]
 
 [dependencies]
 base64 = "^0.20"
@@ -40,11 +40,12 @@ serde = { version = "~1", features = ["derive"] }
 serde_json = "~1"
 serde_with = "~2"
 void = "1.0.2"
-aws-sigv4 = { version = ">= 0.10", optional = true }
-aws-types = { version = ">= 0.10", optional = true }
+aws-credential-types = { version = ">= 0.53", optional = true }
+aws-sigv4 = { version = ">= 0.53", optional = true }
+aws-types = { version = ">= 0.53", optional = true }
 
 [dev-dependencies]
-aws-config = ">= 0.10"
+aws-config = ">= 0.53"
 chrono = { version = "^0.4", features = ["serde"] }
 clap = "~2"
 failure = "0.1.5"

--- a/opensearch/src/auth.rs
+++ b/opensearch/src/auth.rs
@@ -52,7 +52,7 @@ pub enum Credentials {
     /// This requires the `aws-auth` feature to be enabled.
     #[cfg(feature = "aws-auth")]
     AwsSigV4(
-        aws_types::credentials::SharedCredentialsProvider,
+        aws_credential_types::provider::SharedCredentialsProvider,
         aws_types::region::Region,
     ),
 }

--- a/opensearch/src/http/aws_auth.rs
+++ b/opensearch/src/http/aws_auth.rs
@@ -11,15 +11,15 @@
 
 use std::time::SystemTime;
 
+use aws_credential_types::{
+    Credentials, 
+    provider::{ProvideCredentials, SharedCredentialsProvider}
+};
 use aws_sigv4::{
     http_request::{sign, SignableBody, SignableRequest, SigningParams, SigningSettings},
     signing_params::BuildError,
 };
-use aws_types::{
-    credentials::{ProvideCredentials, SharedCredentialsProvider},
-    region::Region,
-    Credentials,
-};
+use aws_types::region::Region;
 use reqwest::Request;
 
 const SERVICE_NAME: &str = "es";


### PR DESCRIPTION
### Description
Bump `aws-*` dependencies from `>= 0.10` to `>= 0.53`
Credential types were split from `aws-types` into `aws-credential-types`

### Issues Resolved
Resolves #106 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
