### PR TITLE
Add cargo cache to Github actions to speed up builds

### DIFF
--- a/.github/workflows/test-integrations-unreleased.yml
+++ b/.github/workflows/test-integrations-unreleased.yml
@@ -40,13 +40,6 @@ jobs:
           sudo sysctl -w fs.file-max=262144
           sudo sysctl -w vm.max_map_count=262144
 
-      - name: Install latest nightly
-        uses: actions-rs/toolchain@v1
-        with:
-            toolchain: nightly
-            override: true
-            components: rustfmt, clippy
-
       - name: Integ OpenSearch ${{ matrix.entry.opensearch_ref }} secured=false
         run: "./.ci/run-tests opensearch SNAPSHOT false"
 

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -29,11 +29,6 @@ jobs:
           sudo sysctl -w vm.swappiness=1
           sudo sysctl -w fs.file-max=262144
           sudo sysctl -w vm.max_map_count=262144
-      - name: Install latest stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-            toolchain: stable
-            components: rustfmt, clippy
       - name: Integ OpenSearch ${{ matrix.entry.version }} secured=${{ matrix.secured }}
         run: "./.ci/run-tests opensearch ${{ matrix.entry.version }} ${{ matrix.secured }}"
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,14 @@ jobs:
       - name: Install latest stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: stable
-            components: rustfmt, clippy, llvm-tools-preview
+          toolchain: stable
+          components: rustfmt, clippy, llvm-tools-preview
+      - name: Install cargo-make
+        uses: davidB/rust-cargo-make@v1
+      - name: Cargo Cache
+        uses: Swatinem/rust-cache@v2
       - name: Setup Tools
-        run: cargo install grcov cargo-make
+        run: cargo install grcov
       - name: Run Unit Tests
         run: |
           cargo make unittest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - [BUG] cargo make test fails out of the box ([#117](https://github.com/opensearch-project/opensearch-rs/pull/117))
 - Update CI to run cargo make test fails out of the box ([#120](https://github.com/opensearch-project/opensearch-rs/pull/120))
+- Add cargo cache to Github actions to speed up builds ([#121](https://github.com/opensearch-project/opensearch-rs/pull/121))
 
 ### Security
 


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Add cargo cache to Github actions to speed up builds

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
