### PR TITLE
Add @reta to MAINTAINERS.md and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @dblock @Xtansia @VachaShah @aditjind
+*   @dblock @Xtansia @VachaShah @aditjind @reta

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,3 +10,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Thomas Farr        | [Xtansia](https://github.com/Xtansia)     | Amazon      |
 | Vacha Shah         | [VachaShah](https://github.com/VachaShah) | Amazon      |
 | Aditya Jindal      | [aditjind](https://github.com/aditjind)   | aditjind    |
+| Andriy Redko       | [reta](https://github.com/reta)           | Aiven       |


### PR DESCRIPTION
### Description
Adds @reta to MAINTAINERS.md and CODEOWNERS following a vote and unanimous approval by the current maintainers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
