### PR TITLE
Replace deprecated `failure` crate with `anyhow`

### DIFF
--- a/api_generator/Cargo.toml
+++ b/api_generator/Cargo.toml
@@ -9,9 +9,9 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
+anyhow = "1.0"
 array_tool = "1.0.3"
 dialoguer = "0.10.2"
-failure = "0.1.5"
 flate2 = "~1"
 globset = "~0.4"
 Inflector = "0.11.4"

--- a/api_generator/src/bin/run.rs
+++ b/api_generator/src/bin/run.rs
@@ -25,7 +25,7 @@ use std::{
     path::Path,
 };
 
-fn main() -> Result<(), failure::Error> {
+fn main() -> anyhow::Result<()> {
     simple_logger::SimpleLogger::new()
         .with_level(log::LevelFilter::Info)
         .init()

--- a/api_generator/src/generator/code_gen/namespace_clients.rs
+++ b/api_generator/src/generator/code_gen/namespace_clients.rs
@@ -26,7 +26,7 @@ use syn::parse_quote;
 use super::{doc, ident, stability_doc, use_declarations};
 
 /// Generates the source code for a namespaced client
-pub fn generate(api: &Api, docs_dir: &Path) -> Result<Vec<(String, String)>, failure::Error> {
+pub fn generate(api: &Api, docs_dir: &Path) -> anyhow::Result<Vec<(String, String)>> {
     let mut output = Vec::new();
 
     for (namespace_name, namespace) in &api.namespaces {

--- a/api_generator/src/generator/code_gen/params.rs
+++ b/api_generator/src/generator/code_gen/params.rs
@@ -22,7 +22,7 @@ use inflector::Inflector;
 use proc_macro2::Span;
 use regex::Regex;
 
-pub fn generate(api: &Api) -> Result<String, failure::Error> {
+pub fn generate(api: &Api) -> anyhow::Result<String> {
     let mut tokens = quote!(
         use serde::{Serialize, Deserialize};
     );

--- a/api_generator/src/generator/code_gen/root.rs
+++ b/api_generator/src/generator/code_gen/root.rs
@@ -24,7 +24,7 @@ use quote::{quote, TokenStreamExt};
 use std::path::Path;
 
 /// Generates the source code for the methods on the root of Elasticsearch
-pub fn generate(api: &Api, docs_dir: &Path) -> Result<String, failure::Error> {
+pub fn generate(api: &Api, docs_dir: &Path) -> anyhow::Result<String> {
     let mut tokens = TokenStream::new();
     tokens.append_all(use_declarations());
 

--- a/api_generator/src/generator/mod.rs
+++ b/api_generator/src/generator/mod.rs
@@ -533,7 +533,7 @@ pub fn generate(
     branch: &str,
     download_dir: &std::path::Path,
     generated_dir: &std::path::Path,
-) -> Result<(), failure::Error> {
+) -> anyhow::Result<()> {
     // read the Api from file
     let api = read_api(branch, download_dir)?;
 
@@ -610,7 +610,7 @@ pub use bulk::*;
 }
 
 /// Reads Api from a directory of REST Api specs
-pub fn read_api(branch: &str, download_dir: &std::path::Path) -> Result<Api, failure::Error> {
+pub fn read_api(branch: &str, download_dir: &std::path::Path) -> anyhow::Result<Api> {
     let paths = fs::read_dir(download_dir)?;
     let mut namespaces = BTreeMap::<String, ApiNamespace>::new();
     let mut enums: HashSet<ApiEnum> = HashSet::new();
@@ -699,10 +699,7 @@ pub fn read_api(branch: &str, download_dir: &std::path::Path) -> Result<Api, fai
 }
 
 /// deserializes an ApiEndpoint from a file
-fn endpoint_from_file<R>(
-    name: String,
-    reader: &mut R,
-) -> Result<(String, ApiEndpoint), failure::Error>
+fn endpoint_from_file<R>(name: String, reader: &mut R) -> anyhow::Result<(String, ApiEndpoint)>
 where
     R: Read,
 {
@@ -741,7 +738,7 @@ where
 }
 
 /// deserializes Common from a file
-fn common_params_from_file<R>(name: String, reader: &mut R) -> Result<Common, failure::Error>
+fn common_params_from_file<R>(name: String, reader: &mut R) -> anyhow::Result<Common>
 where
     R: Read,
 {

--- a/api_generator/src/rest_spec/mod.rs
+++ b/api_generator/src/rest_spec/mod.rs
@@ -25,7 +25,7 @@ use reqwest::{
 use std::{fs::File, io, path::Path};
 use tar::{Archive, Entry};
 
-pub fn download_specs(branch: &str, download_dir: &Path) -> Result<(), failure::Error> {
+pub fn download_specs(branch: &str, download_dir: &Path) -> anyhow::Result<()> {
     let url = format!(
         "https://api.github.com/repos/elastic/elasticsearch/tarball/{}",
         branch
@@ -62,7 +62,7 @@ pub fn download_specs(branch: &str, download_dir: &Path) -> Result<(), failure::
 fn write_spec_file(
     download_dir: &Path,
     mut entry: Entry<GzDecoder<Response>>,
-) -> Result<(), failure::Error> {
+) -> anyhow::Result<()> {
     let path = entry.path()?;
     let mut dir = download_dir.to_path_buf();
     dir.push(path.file_name().unwrap());

--- a/opensearch/Cargo.toml
+++ b/opensearch/Cargo.toml
@@ -45,10 +45,10 @@ aws-sigv4 = { version = ">= 0.53", optional = true }
 aws-types = { version = ">= 0.53", optional = true }
 
 [dev-dependencies]
+anyhow = "1.0"
 aws-config = ">= 0.53"
 chrono = { version = "^0.4", features = ["serde"] }
 clap = "~2"
-failure = "0.1.5"
 futures = "0.3.1"
 http = "0.2"
 hyper = { version = "0.14", default-features = false, features = ["tcp", "stream", "server"] }

--- a/opensearch/src/http/request.rs
+++ b/opensearch/src/http/request.rs
@@ -203,7 +203,7 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn serialize_into_jsonbody_writes_to_bytes() -> Result<(), failure::Error> {
+    fn serialize_into_jsonbody_writes_to_bytes() -> anyhow::Result<()> {
         let mut bytes = BytesMut::new();
         let body: JsonBody<_> = json!({"foo":"bar","baz":1}).into();
         body.write(&mut bytes)?;
@@ -214,7 +214,7 @@ mod tests {
     }
 
     #[test]
-    fn bodies_into_ndbody_writes_to_bytes() -> Result<(), failure::Error> {
+    fn bodies_into_ndbody_writes_to_bytes() -> anyhow::Result<()> {
         let mut bytes = BytesMut::new();
         let mut bodies: Vec<JsonBody<_>> = Vec::with_capacity(2);
         bodies.push(json!({"item":1}).into());
@@ -228,7 +228,7 @@ mod tests {
     }
 
     #[test]
-    fn bytes_body_writes_to_bytes_mut() -> Result<(), failure::Error> {
+    fn bytes_body_writes_to_bytes_mut() -> anyhow::Result<()> {
         let mut bytes_mut = BytesMut::with_capacity(21);
         let bytes = bytes::Bytes::from(&b"{\"foo\":\"bar\",\"baz\":1}"[..]);
         bytes.write(&mut bytes_mut)?;
@@ -238,7 +238,7 @@ mod tests {
     }
 
     #[test]
-    fn bytes_body_returns_usable_buf() -> Result<(), failure::Error> {
+    fn bytes_body_returns_usable_buf() -> anyhow::Result<()> {
         let mut bytes_mut = BytesMut::with_capacity(21);
         let buf = bytes::Bytes::from(&b"{\"foo\":\"bar\",\"baz\":1}"[..]);
 
@@ -251,7 +251,7 @@ mod tests {
     }
 
     #[test]
-    fn vec_body_writes_to_bytes_mut() -> Result<(), failure::Error> {
+    fn vec_body_writes_to_bytes_mut() -> anyhow::Result<()> {
         let mut bytes_mut = BytesMut::with_capacity(21);
         let bytes = b"{\"foo\":\"bar\",\"baz\":1}".to_vec();
         bytes.write(&mut bytes_mut)?;
@@ -261,7 +261,7 @@ mod tests {
     }
 
     #[test]
-    fn bytes_slice_body_writes_to_bytes_mut() -> Result<(), failure::Error> {
+    fn bytes_slice_body_writes_to_bytes_mut() -> anyhow::Result<()> {
         let mut bytes_mut = BytesMut::with_capacity(21);
         let bytes: &'static [u8] = b"{\"foo\":\"bar\",\"baz\":1}";
         bytes.write(&mut bytes_mut)?;
@@ -271,7 +271,7 @@ mod tests {
     }
 
     #[test]
-    fn string_body_writes_to_bytes_mut() -> Result<(), failure::Error> {
+    fn string_body_writes_to_bytes_mut() -> anyhow::Result<()> {
         let mut bytes_mut = BytesMut::with_capacity(21);
         let s = String::from("{\"foo\":\"bar\",\"baz\":1}");
         s.write(&mut bytes_mut)?;
@@ -281,7 +281,7 @@ mod tests {
     }
 
     #[test]
-    fn string_slice_body_writes_to_bytes_mut() -> Result<(), failure::Error> {
+    fn string_slice_body_writes_to_bytes_mut() -> anyhow::Result<()> {
         let mut bytes_mut = BytesMut::with_capacity(21);
         let s: &'static str = "{\"foo\":\"bar\",\"baz\":1}";
         s.write(&mut bytes_mut)?;

--- a/opensearch/src/http/response.rs
+++ b/opensearch/src/http/response.rs
@@ -383,7 +383,7 @@ pub mod tests {
     use serde_json::json;
 
     #[test]
-    fn deserialize_error_string() -> Result<(), failure::Error> {
+    fn deserialize_error_string() -> anyhow::Result<()> {
         let json = r#"{"error":"no handler found for uri [/test_1/test/1/_update?_source=foo%2Cbar] and method [POST]"}"#;
         let ex: Exception = serde_json::from_str(json)?;
 
@@ -395,7 +395,7 @@ pub mod tests {
     }
 
     #[test]
-    fn deserialize_illegal_argument_exception() -> Result<(), failure::Error> {
+    fn deserialize_illegal_argument_exception() -> anyhow::Result<()> {
         let json = r#"{
           "error": {
             "root_cause": [{
@@ -489,7 +489,7 @@ pub mod tests {
     }
 
     #[test]
-    fn deserialize_index_not_found_exception() -> Result<(), failure::Error> {
+    fn deserialize_index_not_found_exception() -> anyhow::Result<()> {
         let json = r#"{
           "error": {
             "root_cause": [{

--- a/opensearch/src/root/bulk.rs
+++ b/opensearch/src/root/bulk.rs
@@ -691,7 +691,7 @@ mod tests {
     }
 
     #[test]
-    fn serialize_bulk_operations_with_same_type_writes_to_bytes() -> Result<(), failure::Error> {
+    fn serialize_bulk_operations_with_same_type_writes_to_bytes() -> anyhow::Result<()> {
         let mut bytes = BytesMut::new();
         let mut ops: Vec<BulkOperation<Value>> = Vec::with_capacity(4);
 
@@ -764,8 +764,7 @@ mod tests {
     }
 
     #[test]
-    fn serialize_bulk_operations_with_different_types_writes_to_bytes() -> Result<(), failure::Error>
-    {
+    fn serialize_bulk_operations_with_different_types_writes_to_bytes() -> anyhow::Result<()> {
         #[derive(Serialize)]
         struct IndexDoc<'a> {
             foo: &'a str,

--- a/opensearch/tests/auth.rs
+++ b/opensearch/tests/auth.rs
@@ -37,7 +37,7 @@ use base64::{prelude::BASE64_STANDARD, write::EncoderWriter as Base64Encoder};
 use std::io::Write;
 
 #[tokio::test]
-async fn basic_auth_header() -> Result<(), failure::Error> {
+async fn basic_auth_header() -> anyhow::Result<()> {
     let server = server::http(move |req| async move {
         let mut header_value = b"Basic ".to_vec();
         {
@@ -62,7 +62,7 @@ async fn basic_auth_header() -> Result<(), failure::Error> {
 }
 
 #[tokio::test]
-async fn api_key_header() -> Result<(), failure::Error> {
+async fn api_key_header() -> anyhow::Result<()> {
     let server = server::http(move |req| async move {
         let mut header_value = b"ApiKey ".to_vec();
         {
@@ -87,7 +87,7 @@ async fn api_key_header() -> Result<(), failure::Error> {
 }
 
 #[tokio::test]
-async fn bearer_header() -> Result<(), failure::Error> {
+async fn bearer_header() -> anyhow::Result<()> {
     let server = server::http(move |req| async move {
         assert_eq!(req.headers()["authorization"], "Bearer access_token");
         http::Response::default()
@@ -104,7 +104,7 @@ async fn bearer_header() -> Result<(), failure::Error> {
 
 // TODO: test PKI authentication. Could configure a HttpsConnector, maybe using https://github.com/sfackler/hyper-openssl?, or send to PKI configured Elasticsearch.
 //#[tokio::test]
-//async fn client_certificate() -> Result<(), failure::Error> {
+//async fn client_certificate() -> anyhow::Result<()> {
 //    let server = server::http(move |req| {
 //        async move {
 //            http::Response::default()

--- a/opensearch/tests/aws_auth.rs
+++ b/opensearch/tests/aws_auth.rs
@@ -23,7 +23,7 @@ use aws_types::region::Region;
 use std::convert::TryInto;
 
 #[tokio::test]
-async fn aws_auth_get() -> Result<(), failure::Error> {
+async fn aws_auth_get() -> anyhow::Result<()> {
     let server = server::http(move |req| async move {
         let authorization_header = req.headers()["authorization"].to_str().unwrap();
         let re = Regex::new(r"^AWS4-HMAC-SHA256 Credential=id/\d*/us-west-1/custom/aws4_request, SignedHeaders=accept;content-type;host;x-amz-content-sha256;x-amz-date, Signature=[a-f,0-9].*$").unwrap();
@@ -47,7 +47,7 @@ async fn aws_auth_get() -> Result<(), failure::Error> {
 }
 
 #[tokio::test]
-async fn aws_auth_post() -> Result<(), failure::Error> {
+async fn aws_auth_post() -> anyhow::Result<()> {
     let server = server::http(move |req| async move {
         let amz_content_sha256_header = req.headers()["x-amz-content-sha256"].to_str().unwrap();
         assert_eq!(
@@ -72,7 +72,7 @@ async fn aws_auth_post() -> Result<(), failure::Error> {
     Ok(())
 }
 
-fn create_aws_client(addr: &str) -> Result<OpenSearch, failure::Error> {
+fn create_aws_client(addr: &str) -> anyhow::Result<OpenSearch> {
     let aws_creds = Credentials::new("id", "secret", None, None, "token");
     let creds_provider = SharedCredentialsProvider::new(aws_creds);
     let aws_config = SdkConfig::builder()

--- a/opensearch/tests/client.rs
+++ b/opensearch/tests/client.rs
@@ -50,7 +50,7 @@ use serde_json::{json, Value};
 use std::time::Duration;
 
 #[tokio::test]
-async fn default_user_agent_content_type_accept_headers() -> Result<(), failure::Error> {
+async fn default_user_agent_content_type_accept_headers() -> anyhow::Result<()> {
     let server = server::http(move |req| async move {
         assert_eq!(req.headers()["user-agent"], DEFAULT_USER_AGENT);
         assert_eq!(req.headers()["content-type"], "application/json");
@@ -65,7 +65,7 @@ async fn default_user_agent_content_type_accept_headers() -> Result<(), failure:
 }
 
 #[tokio::test]
-async fn default_header() -> Result<(), failure::Error> {
+async fn default_header() -> anyhow::Result<()> {
     let server = server::http(move |req| async move {
         assert_eq!(req.headers()["x-opaque-id"], "foo");
         http::Response::default()
@@ -83,7 +83,7 @@ async fn default_header() -> Result<(), failure::Error> {
 }
 
 #[tokio::test]
-async fn override_default_header() -> Result<(), failure::Error> {
+async fn override_default_header() -> anyhow::Result<()> {
     let server = server::http(move |req| async move {
         assert_eq!(req.headers()["x-opaque-id"], "bar");
         http::Response::default()
@@ -108,7 +108,7 @@ async fn override_default_header() -> Result<(), failure::Error> {
 }
 
 #[tokio::test]
-async fn x_opaque_id_header() -> Result<(), failure::Error> {
+async fn x_opaque_id_header() -> anyhow::Result<()> {
     let server = server::http(move |req| async move {
         assert_eq!(req.headers()["x-opaque-id"], "foo");
         http::Response::default()
@@ -193,7 +193,7 @@ async fn call_request_timeout_supersedes_global_timeout() {
 }
 
 #[tokio::test]
-async fn deprecation_warning_headers() -> Result<(), failure::Error> {
+async fn deprecation_warning_headers() -> anyhow::Result<()> {
     let client = client::create_default();
     let _ = index_documents(&client).await?;
     let response = client
@@ -238,7 +238,7 @@ async fn deprecation_warning_headers() -> Result<(), failure::Error> {
 }
 
 #[tokio::test]
-async fn serialize_querystring() -> Result<(), failure::Error> {
+async fn serialize_querystring() -> anyhow::Result<()> {
     let server = server::http(move |req| async move {
         assert_eq!(req.method(), Method::GET);
         assert_eq!(req.uri().path(), "/_search");
@@ -263,7 +263,7 @@ async fn serialize_querystring() -> Result<(), failure::Error> {
 }
 
 #[tokio::test]
-async fn search_with_body() -> Result<(), failure::Error> {
+async fn search_with_body() -> anyhow::Result<()> {
     let client = client::create_default();
     let _ = index_documents(&client).await?;
     let response = client
@@ -306,7 +306,7 @@ async fn search_with_body() -> Result<(), failure::Error> {
 }
 
 #[tokio::test]
-async fn search_with_no_body() -> Result<(), failure::Error> {
+async fn search_with_no_body() -> anyhow::Result<()> {
     let client = client::create_default();
     let _ = index_documents(&client).await?;
     let response = client
@@ -329,7 +329,7 @@ async fn search_with_no_body() -> Result<(), failure::Error> {
 }
 
 #[tokio::test]
-async fn read_response_as_bytes() -> Result<(), failure::Error> {
+async fn read_response_as_bytes() -> anyhow::Result<()> {
     let client = client::create_default();
     let _ = index_documents(&client).await?;
     let response = client
@@ -355,7 +355,7 @@ async fn read_response_as_bytes() -> Result<(), failure::Error> {
 }
 
 #[tokio::test]
-async fn cat_health_format_json() -> Result<(), failure::Error> {
+async fn cat_health_format_json() -> anyhow::Result<()> {
     let client = client::create_default();
     let response = client
         .cat()
@@ -379,7 +379,7 @@ async fn cat_health_format_json() -> Result<(), failure::Error> {
 }
 
 #[tokio::test]
-async fn cat_health_header_json() -> Result<(), failure::Error> {
+async fn cat_health_header_json() -> anyhow::Result<()> {
     let client = client::create_default();
     let response = client
         .cat()
@@ -403,7 +403,7 @@ async fn cat_health_header_json() -> Result<(), failure::Error> {
 }
 
 #[tokio::test]
-async fn cat_health_text() -> Result<(), failure::Error> {
+async fn cat_health_text() -> anyhow::Result<()> {
     let client = client::create_default();
     let response = client.cat().health().pretty(true).send().await?;
 
@@ -421,7 +421,7 @@ async fn cat_health_text() -> Result<(), failure::Error> {
 }
 
 #[tokio::test]
-async fn clone_search_with_body() -> Result<(), failure::Error> {
+async fn clone_search_with_body() -> anyhow::Result<()> {
     let client = client::create_default();
     let _ = index_documents(&client).await?;
     let base_request = client.search(SearchParts::None);
@@ -447,7 +447,7 @@ async fn clone_search_with_body() -> Result<(), failure::Error> {
 }
 
 #[tokio::test]
-async fn byte_slice_body() -> Result<(), failure::Error> {
+async fn byte_slice_body() -> anyhow::Result<()> {
     let client = client::create_default();
     let body = b"{\"query\":{\"match_all\":{}}}";
 

--- a/opensearch/tests/error.rs
+++ b/opensearch/tests/error.rs
@@ -37,7 +37,7 @@ use serde_json::{json, Value};
 
 /// Responses in the range 400-599 return Response body
 #[tokio::test]
-async fn bad_request_returns_response() -> Result<(), failure::Error> {
+async fn bad_request_returns_response() -> anyhow::Result<()> {
     let client = client::create_default();
     let response = client
         .explain(ExplainParts::IndexId("non_existent_index", "id"))
@@ -62,7 +62,7 @@ async fn bad_request_returns_response() -> Result<(), failure::Error> {
 }
 
 #[tokio::test]
-async fn deserialize_exception() -> Result<(), failure::Error> {
+async fn deserialize_exception() -> anyhow::Result<()> {
     let client = client::create_default();
     let response = client
         .explain(ExplainParts::IndexId("non_existent_index", "id"))

--- a/yaml_test_runner/Cargo.toml
+++ b/yaml_test_runner/Cargo.toml
@@ -12,9 +12,9 @@ license = "Apache-2.0"
 opensearch = { path = "../opensearch", features = ["experimental-apis"]}
 api_generator = { path = "./../api_generator" }
 
+anyhow = "1.0"
 base64 = "^0.21"
 clap = "~2"
-failure = "0.1.6"
 itertools = "0.10.0"
 Inflector = "0.11.4"
 lazy_static = "1.4.0"

--- a/yaml_test_runner/src/github.rs
+++ b/yaml_test_runner/src/github.rs
@@ -40,7 +40,7 @@ use std::{fs, fs::File, io, path::Path};
 use tar::{Archive, Entry};
 
 /// Downloads the yaml tests if not already downloaded
-pub fn download_test_suites(branch: &str, download_dir: &Path) -> Result<(), failure::Error> {
+pub fn download_test_suites(branch: &str, download_dir: &Path) -> anyhow::Result<()> {
     let last_downloaded_version = download_dir.join("last_downloaded_version");
     if last_downloaded_version.exists() {
         let version = fs::read_to_string(&last_downloaded_version)
@@ -94,7 +94,7 @@ fn write_test_file(
     download_dir: &Path,
     suite_dir: &str,
     mut entry: Entry<GzDecoder<Response>>,
-) -> Result<(), failure::Error> {
+) -> anyhow::Result<()> {
     let path = entry.path()?;
 
     let mut dir = {

--- a/yaml_test_runner/src/main.rs
+++ b/yaml_test_runner/src/main.rs
@@ -48,7 +48,7 @@ mod step;
 
 use generator::TestSuite;
 
-fn main() -> Result<(), failure::Error> {
+fn main() -> anyhow::Result<()> {
     simple_logger::SimpleLogger::new()
         .with_level(LevelFilter::Info)
         .init()
@@ -142,7 +142,7 @@ fn main() -> Result<(), failure::Error> {
 
 fn branch_suite_and_version_from_opensearch(
     url: &str,
-) -> Result<(String, TestSuite, semver::Version), failure::Error> {
+) -> anyhow::Result<(String, TestSuite, semver::Version)> {
     let client = ClientBuilder::new()
         .danger_accept_invalid_certs(true)
         .build()?;

--- a/yaml_test_runner/src/step/comparison.rs
+++ b/yaml_test_runner/src/step/comparison.rs
@@ -30,6 +30,7 @@
 
 use super::Step;
 use crate::step::Expr;
+use anyhow::anyhow;
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens, TokenStreamExt};
 use yaml_rust::Yaml;
@@ -49,15 +50,15 @@ impl From<Comparison> for Step {
 }
 
 impl Comparison {
-    pub fn try_parse(yaml: &Yaml, op: &str) -> Result<Comparison, failure::Error> {
+    pub fn try_parse(yaml: &Yaml, op: &str) -> anyhow::Result<Comparison> {
         let hash = yaml
             .as_hash()
-            .ok_or_else(|| failure::err_msg(format!("expected hash but found {:?}", yaml)))?;
+            .ok_or_else(|| anyhow!("expected hash but found {:?}", yaml))?;
 
         let (k, v) = hash.iter().next().unwrap();
         let expr = k
             .as_str()
-            .ok_or_else(|| failure::err_msg(format!("expected string key but found {:?}", k)))?;
+            .ok_or_else(|| anyhow!("expected string key but found {:?}", k))?;
 
         Ok(Comparison {
             expr: expr.into(),

--- a/yaml_test_runner/src/step/contains.rs
+++ b/yaml_test_runner/src/step/contains.rs
@@ -30,6 +30,7 @@
 
 use super::Step;
 use crate::step::{json_string_from_yaml, Expr};
+use anyhow::anyhow;
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens, TokenStreamExt};
 use yaml_rust::Yaml;
@@ -46,10 +47,10 @@ impl From<Contains> for Step {
 }
 
 impl Contains {
-    pub fn try_parse(yaml: &Yaml) -> Result<Contains, failure::Error> {
+    pub fn try_parse(yaml: &Yaml) -> anyhow::Result<Contains> {
         let hash = yaml
             .as_hash()
-            .ok_or_else(|| failure::err_msg(format!("expected hash but found {:?}", yaml)))?;
+            .ok_or_else(|| anyhow!("expected hash but found {:?}", yaml))?;
 
         let (k, v) = hash.iter().next().unwrap();
         let expr = k.as_str().unwrap().trim();

--- a/yaml_test_runner/src/step/is_false.rs
+++ b/yaml_test_runner/src/step/is_false.rs
@@ -30,6 +30,7 @@
 
 use super::Step;
 use crate::step::Expr;
+use anyhow::anyhow;
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens, TokenStreamExt};
 use yaml_rust::Yaml;
@@ -45,10 +46,10 @@ impl From<IsFalse> for Step {
 }
 
 impl IsFalse {
-    pub fn try_parse(yaml: &Yaml) -> Result<IsFalse, failure::Error> {
-        let expr = yaml.as_str().ok_or_else(|| {
-            failure::err_msg(format!("expected string key but found {:?}", &yaml))
-        })?;
+    pub fn try_parse(yaml: &Yaml) -> anyhow::Result<IsFalse> {
+        let expr = yaml
+            .as_str()
+            .ok_or_else(|| anyhow!("expected string key but found {:?}", &yaml))?;
 
         Ok(IsFalse { expr: expr.into() })
     }

--- a/yaml_test_runner/src/step/is_true.rs
+++ b/yaml_test_runner/src/step/is_true.rs
@@ -30,6 +30,7 @@
 
 use super::Step;
 use crate::step::Expr;
+use anyhow::anyhow;
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens, TokenStreamExt};
 use yaml_rust::Yaml;
@@ -45,10 +46,10 @@ impl From<IsTrue> for Step {
 }
 
 impl IsTrue {
-    pub fn try_parse(yaml: &Yaml) -> Result<IsTrue, failure::Error> {
-        let expr = yaml.as_str().ok_or_else(|| {
-            failure::err_msg(format!("expected string key but found {:?}", &yaml))
-        })?;
+    pub fn try_parse(yaml: &Yaml) -> anyhow::Result<IsTrue> {
+        let expr = yaml
+            .as_str()
+            .ok_or_else(|| anyhow!("expected string key but found {:?}", &yaml))?;
 
         Ok(IsTrue { expr: expr.into() })
     }

--- a/yaml_test_runner/src/step/length.rs
+++ b/yaml_test_runner/src/step/length.rs
@@ -30,6 +30,7 @@
 
 use super::Step;
 use crate::step::Expr;
+use anyhow::anyhow;
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens, TokenStreamExt};
 use yaml_rust::Yaml;
@@ -46,20 +47,20 @@ impl From<Length> for Step {
 }
 
 impl Length {
-    pub fn try_parse(yaml: &Yaml) -> Result<Length, failure::Error> {
+    pub fn try_parse(yaml: &Yaml) -> anyhow::Result<Length> {
         let hash = yaml
             .as_hash()
-            .ok_or_else(|| failure::err_msg(format!("expected hash but found {:?}", yaml)))?;
+            .ok_or_else(|| anyhow!("expected hash but found {:?}", yaml))?;
 
         let (k, v) = hash.iter().next().unwrap();
 
         let expr = k
             .as_str()
-            .ok_or_else(|| failure::err_msg(format!("expected string key but found {:?}", k)))?;
+            .ok_or_else(|| anyhow!("expected string key but found {:?}", k))?;
 
         let len = v
             .as_i64()
-            .ok_or_else(|| failure::err_msg(format!("expected i64 but found {:?}", v)))?;
+            .ok_or_else(|| anyhow!("expected i64 but found {:?}", v))?;
 
         Ok(Length {
             len: len as usize,

--- a/yaml_test_runner/src/step/match.rs
+++ b/yaml_test_runner/src/step/match.rs
@@ -33,6 +33,7 @@ use crate::{
     regex::clean_regex,
     step::{json_string_from_yaml, Expr},
 };
+use anyhow::anyhow;
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens, TokenStreamExt};
 use yaml_rust::Yaml;
@@ -49,10 +50,10 @@ impl From<Match> for Step {
 }
 
 impl Match {
-    pub fn try_parse(yaml: &Yaml) -> Result<Match, failure::Error> {
+    pub fn try_parse(yaml: &Yaml) -> anyhow::Result<Match> {
         let hash = yaml
             .as_hash()
-            .ok_or_else(|| failure::err_msg(format!("expected hash but found {:?}", yaml)))?;
+            .ok_or_else(|| anyhow!("expected hash but found {:?}", yaml))?;
 
         let (k, v) = hash.iter().next().unwrap();
         let expr = k.as_str().unwrap().trim();

--- a/yaml_test_runner/src/step/mod.rs
+++ b/yaml_test_runner/src/step/mod.rs
@@ -29,6 +29,7 @@
  */
 
 use crate::regex::*;
+use anyhow::anyhow;
 use api_generator::generator::Api;
 use proc_macro2::TokenStream;
 use std::fmt::Write;
@@ -55,18 +56,18 @@ pub use set::*;
 pub use skip::*;
 pub use transform_and_set::*;
 
-pub fn parse_steps(api: &Api, steps: &[Yaml]) -> Result<Vec<Step>, failure::Error> {
+pub fn parse_steps(api: &Api, steps: &[Yaml]) -> anyhow::Result<Vec<Step>> {
     let mut parsed_steps: Vec<Step> = Vec::new();
     for step in steps {
         let hash = step
             .as_hash()
-            .ok_or_else(|| failure::err_msg(format!("expected hash but found {:?}", step)))?;
+            .ok_or_else(|| anyhow!("expected hash but found {:?}", step))?;
 
         let (key, value) = {
             let (k, yaml) = hash.iter().next().unwrap();
-            let key = k.as_str().ok_or_else(|| {
-                failure::err_msg(format!("expected string key but found {:?}", k))
-            })?;
+            let key = k
+                .as_str()
+                .ok_or_else(|| anyhow!("expected string key but found {:?}", k))?;
 
             (key, yaml)
         };
@@ -112,7 +113,7 @@ pub fn parse_steps(api: &Api, steps: &[Yaml]) -> Result<Vec<Step>, failure::Erro
                 let comp = Comparison::try_parse(value, op)?;
                 parsed_steps.push(comp.into())
             }
-            op => return Err(failure::err_msg(format!("unknown step operation: {}", op))),
+            op => return Err(anyhow!("unknown step operation: {}", op)),
         }
     }
 
@@ -234,7 +235,7 @@ impl Step {
 
 /// Checks whether there are any Errs in the collection, and accumulates them into one
 /// error message if there are.
-pub fn ok_or_accumulate<T>(results: &[Result<T, failure::Error>]) -> Result<(), failure::Error> {
+pub fn ok_or_accumulate<T>(results: &[anyhow::Result<T>]) -> anyhow::Result<()> {
     let errs = results
         .iter()
         .filter_map(|r| r.as_ref().err())
@@ -245,7 +246,7 @@ pub fn ok_or_accumulate<T>(results: &[Result<T, failure::Error>]) -> Result<(), 
         let mut msgs = errs.iter().map(|e| e.to_string()).collect::<Vec<_>>();
         msgs.sort();
         msgs.dedup_by(|a, b| a == b);
-        Err(failure::err_msg(msgs.join(", ")))
+        Err(anyhow!("{}", msgs.join(", ")))
     }
 }
 

--- a/yaml_test_runner/src/step/set.rs
+++ b/yaml_test_runner/src/step/set.rs
@@ -30,6 +30,7 @@
 
 use super::Step;
 use crate::step::Expr;
+use anyhow::anyhow;
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens, TokenStreamExt};
 use yaml_rust::Yaml;
@@ -46,19 +47,19 @@ impl From<Set> for Step {
 }
 
 impl Set {
-    pub fn try_parse(yaml: &Yaml) -> Result<Set, failure::Error> {
+    pub fn try_parse(yaml: &Yaml) -> anyhow::Result<Set> {
         let hash = yaml
             .as_hash()
-            .ok_or_else(|| failure::err_msg(format!("expected hash but found {:?}", yaml)))?;
+            .ok_or_else(|| anyhow!("expected hash but found {:?}", yaml))?;
 
         let (k, v) = hash.iter().next().unwrap();
         let expr = k
             .as_str()
-            .ok_or_else(|| failure::err_msg(format!("expected string key but found {:?}", k)))?;
+            .ok_or_else(|| anyhow!("expected string key but found {:?}", k))?;
 
         let id = v
             .as_str()
-            .ok_or_else(|| failure::err_msg(format!("expected string value but found {:?}", v)))?;
+            .ok_or_else(|| anyhow!("expected string value but found {:?}", v))?;
 
         Ok(Set {
             ident: syn::Ident::new(id, Span::call_site()),

--- a/yaml_test_runner/src/step/skip.rs
+++ b/yaml_test_runner/src/step/skip.rs
@@ -104,7 +104,7 @@ impl Skip {
         }
     }
 
-    pub fn try_parse(yaml: &Yaml) -> Result<Skip, failure::Error> {
+    pub fn try_parse(yaml: &Yaml) -> anyhow::Result<Skip> {
         let version = yaml["version"]
             .as_str()
             .map_or_else(|| None, |y| Some(y.to_string()));

--- a/yaml_test_runner/src/step/transform_and_set.rs
+++ b/yaml_test_runner/src/step/transform_and_set.rs
@@ -30,6 +30,7 @@
 
 use super::Step;
 use crate::step::Expr;
+use anyhow::anyhow;
 use inflector::Inflector;
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens, TokenStreamExt};
@@ -99,19 +100,19 @@ impl From<TransformAndSet> for Step {
 }
 
 impl TransformAndSet {
-    pub fn try_parse(yaml: &Yaml) -> Result<TransformAndSet, failure::Error> {
+    pub fn try_parse(yaml: &Yaml) -> anyhow::Result<TransformAndSet> {
         let hash = yaml
             .as_hash()
-            .ok_or_else(|| failure::err_msg(format!("expected hash but found {:?}", yaml)))?;
+            .ok_or_else(|| anyhow!("expected hash but found {:?}", yaml))?;
 
         let (k, v) = hash.iter().next().unwrap();
         let ident = k
             .as_str()
-            .ok_or_else(|| failure::err_msg(format!("expected string key but found {:?}", k)))?;
+            .ok_or_else(|| anyhow!("expected string key but found {:?}", k))?;
 
         let transformation = v
             .as_str()
-            .ok_or_else(|| failure::err_msg(format!("expected string value but found {:?}", v)))?;
+            .ok_or_else(|| anyhow!("expected string value but found {:?}", v))?;
 
         Ok(TransformAndSet {
             ident: syn::Ident::new(ident, Span::call_site()),

--- a/yaml_test_runner/tests/common/client.rs
+++ b/yaml_test_runner/tests/common/client.rs
@@ -103,7 +103,7 @@ pub fn get() -> &'static OpenSearch {
 /// and the response parsed from json or yaml
 pub async fn read_response(
     response: Response,
-) -> Result<(Method, StatusCode, String, Value), failure::Error> {
+) -> anyhow::Result<(Method, StatusCode, String, Value)> {
     let is_json = response.content_type().starts_with("application/json");
     let is_yaml = response.content_type().starts_with("application/yaml");
     let method = response.method();


### PR DESCRIPTION
### Description
The `failure` crate has long been deprecated: https://github.com/rust-lang-deprecated/failure
Replacing all it's usages with the `anyhow` crate.
Only used in tests, api_generator & yaml_test_runner.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
