### PR TITLE
Bump `syn` from ~1.0 to ~2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `aws-*` from >=0.10 to >=0.53 ([#108](https://github.com/opensearch-project/opensearch-rs/pull/108))
 - Bumps `toml` from 0.5.6 to 0.7.1
 - Bumps `sysinfo` from 0.26.4 to 0.28.0
+- Bumps `syn` from ~1.0 to ~2.0
 
 ### Changed
 - Updates users guide with complete examples ([#114](https://github.com/opensearch-project/opensearch-rs/pull/114))

--- a/api_generator/Cargo.toml
+++ b/api_generator/Cargo.toml
@@ -28,7 +28,7 @@ semver = "1.0.14"
 serde = { version = "~1", features = ["derive"] }
 serde_json = "~1"
 simple_logger = "4.0.0"
-syn = { version = "~1.0", features = ["extra-traits", "full"] }
+syn = { version = "~2.0", features = ["extra-traits", "full"] }
 tar = "~0.4"
 toml = "0.7.1"
 url = "2.1.1"

--- a/api_generator/src/generator/code_gen/mod.rs
+++ b/api_generator/src/generator/code_gen/mod.rs
@@ -188,7 +188,7 @@ impl GetIdent for ImplItem {
     fn get_ident(&self) -> &syn::Ident {
         match self {
             ImplItem::Const(i) => &i.ident,
-            ImplItem::Method(i) => &i.sig.ident,
+            ImplItem::Fn(i) => &i.sig.ident,
             ImplItem::Type(i) => &i.ident,
             _ => panic!("{:?} has no ident", self),
         }
@@ -295,7 +295,7 @@ pub fn generics(lifetimes: Vec<syn::Lifetime>, types: Vec<syn::TypeParam>) -> sy
     let params: Punctuated<_, _> = lifetimes
         .into_iter()
         .map(|l| {
-            syn::GenericParam::Lifetime(syn::LifetimeDef {
+            syn::GenericParam::Lifetime(syn::LifetimeParam {
                 attrs: vec![],
                 lifetime: l,
                 colon_token: None,
@@ -356,7 +356,7 @@ impl IntoStmt for syn::Item {
 
 impl IntoStmt for syn::Expr {
     fn into_stmt(self) -> syn::Stmt {
-        syn::Stmt::Expr(self)
+        syn::Stmt::Expr(self, Some(syn::token::Semi(Span::call_site())))
     }
 }
 

--- a/api_generator/src/generator/code_gen/url/enum_builder.rs
+++ b/api_generator/src/generator/code_gen/url/enum_builder.rs
@@ -223,12 +223,10 @@ impl<'a> EnumBuilder<'a> {
                         }),
                         _ => syn::Pat::TupleStruct(syn::PatTupleStruct {
                             attrs: vec![],
+                            qself: None,
                             path: match_path,
-                            pat: syn::PatTuple {
-                                attrs: vec![],
-                                paren_token: Paren(Span::call_site()),
-                                elems: fields.into_iter().collect(),
-                            },
+                            paren_token: Paren(Span::call_site()),
+                            elems: fields.into_iter().collect(),
                         }),
                     };
 


### PR DESCRIPTION
### Description
Bumps `syn` from ~1.0 to ~2.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
