### PR TITLE
Skip the search/260_sort_mixed.yml YAML integration test

### DIFF
--- a/yaml_test_runner/skip.yml
+++ b/yaml_test_runner/skip.yml
@@ -41,6 +41,10 @@
       - Bad window deprecated interval
     free/search/230_interval_query.yml:
       - "*"
+    free/search/260_sort_mixed.yml:
+      # Uses values that are not able to be accurately represented as a double
+      # Causing mismatch in rounding between Rust and OpenSearch
+      - "*"
       
   when_secure:
     tests:


### PR DESCRIPTION
### Description
Skip the search/260_sort_mixed.yml YAML integration test

It uses values that are not able to be accurately represented as a double causing mismatch in rounding between Rust and OpenSearch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
