### PR TITLE
Fix f64 comparison: use numeric-based comparison instead of string-based

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Update CI to run cargo make test fails out of the box ([#120](https://github.com/opensearch-project/opensearch-rs/pull/120))
 - Add cargo cache to Github actions to speed up builds ([#121](https://github.com/opensearch-project/opensearch-rs/pull/121))
 - [BUG] Updated Point-in-Time request builder to support current API ([#136](https://github.com/opensearch-project/opensearch-rs/pull/136))
+- Fix f64 comparison: use numeric-based comparison instead of string-based ([#150](https://github.com/opensearch-project/opensearch-rs/pull/150))
 
 ### Security
 

--- a/yaml_test_runner/src/step/match.rs
+++ b/yaml_test_runner/src/step/match.rs
@@ -117,7 +117,7 @@ impl ToTokens for Match {
                     panic!("match on $body with f64");
                 } else {
                     tokens.append_all(quote! {
-                        crate::assert_match!(json#expr, json!(#f));
+                        crate::assert_numeric_match!(json#expr, #f);
                     });
                 }
             }


### PR DESCRIPTION
### Description
Fix f64 comparison: use numeric-based comparison instead of string-based

```
'free::search::_260_sort_mixed::search_across_indices_with_mixed_long_and_double_numeric_types' panicked at 'assertion failed: `(left == right)`
  left: `Number(1.2233720368547758E18)`,
 right: `Number(1.2233720368547758e18)`: expected value json["hits"]["hits"][0]["sort"][0] to match Number(1.2233720368547758e18) but was Number(1.2233720368547758E18)', yaml_test_runner/tests/free/search/_260_sort_mixed.rs:77:5
```

### Issues Resolved
Related to https://github.com/opensearch-project/opensearch-rs/pull/149

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
