### PR TITLE
Use serde_yaml throughout yaml_test_runner instead of yaml-rust

### DIFF
--- a/.ci/opensearch/Dockerfile
+++ b/.ci/opensearch/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /usr/share/opensearch
 
 COPY --chown=opensearch:opensearch opensearch.yml ./config/
 
-RUN ./opensearch-onetime-setup.sh
+RUN if [[ -f "./opensearch-onetime-setup.sh" ]]; then ./opensearch-onetime-setup.sh ; fi
 
 COPY --chown=opensearch:opensearch *.pem ./config/
 

--- a/yaml_test_runner/Cargo.toml
+++ b/yaml_test_runner/Cargo.toml
@@ -33,7 +33,6 @@ simple_logger = "4.0.0"
 syn = { version = "~1.0", features = ["full"] }
 sysinfo = "0.28"
 url = "2.1.1"
-yaml-rust = "0.4.3"
 tar = "~0.4"
 flate2 = "~1"
 globset = "~0.4"

--- a/yaml_test_runner/src/main.rs
+++ b/yaml_test_runner/src/main.rs
@@ -48,6 +48,8 @@ mod step;
 
 use generator::TestSuite;
 
+use crate::skip::GlobalSkips;
+
 fn main() -> anyhow::Result<()> {
     simple_logger::SimpleLogger::new()
         .with_level(LevelFilter::Info)
@@ -128,6 +130,9 @@ fn main() -> anyhow::Result<()> {
         }
     }
 
+    let global_skips = serde_yaml::from_str::<GlobalSkips>(include_str!("../skip.yml"))?;
+    let skips = global_skips.get_skips_for(&version, url.starts_with("https://"));
+
     generator::generate_tests_from_yaml(
         &api,
         &suite,
@@ -135,6 +140,7 @@ fn main() -> anyhow::Result<()> {
         &download_dir,
         &download_dir,
         &generated_dir,
+        &skips,
     )?;
 
     Ok(())

--- a/yaml_test_runner/src/step/comparison.rs
+++ b/yaml_test_runner/src/step/comparison.rs
@@ -33,13 +33,13 @@ use crate::step::Expr;
 use anyhow::anyhow;
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens, TokenStreamExt};
-use yaml_rust::Yaml;
+use serde_yaml::Value;
 
 pub const OPERATORS: [&str; 4] = ["lt", "lte", "gt", "gte"];
 
 pub struct Comparison {
     pub(crate) expr: Expr,
-    value: Yaml,
+    value: Value,
     op: String,
 }
 
@@ -50,9 +50,9 @@ impl From<Comparison> for Step {
 }
 
 impl Comparison {
-    pub fn try_parse(yaml: &Yaml, op: &str) -> anyhow::Result<Comparison> {
+    pub fn try_parse(yaml: &Value, op: &str) -> anyhow::Result<Comparison> {
         let hash = yaml
-            .as_hash()
+            .as_mapping()
             .ok_or_else(|| anyhow!("expected hash but found {:?}", yaml))?;
 
         let (k, v) = hash.iter().next().unwrap();

--- a/yaml_test_runner/src/step/is_false.rs
+++ b/yaml_test_runner/src/step/is_false.rs
@@ -33,7 +33,7 @@ use crate::step::Expr;
 use anyhow::anyhow;
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens, TokenStreamExt};
-use yaml_rust::Yaml;
+use serde_yaml::Value;
 
 pub struct IsFalse {
     pub(crate) expr: Expr,
@@ -46,7 +46,7 @@ impl From<IsFalse> for Step {
 }
 
 impl IsFalse {
-    pub fn try_parse(yaml: &Yaml) -> anyhow::Result<IsFalse> {
+    pub fn try_parse(yaml: &Value) -> anyhow::Result<IsFalse> {
         let expr = yaml
             .as_str()
             .ok_or_else(|| anyhow!("expected string key but found {:?}", &yaml))?;

--- a/yaml_test_runner/src/step/is_true.rs
+++ b/yaml_test_runner/src/step/is_true.rs
@@ -33,7 +33,7 @@ use crate::step::Expr;
 use anyhow::anyhow;
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens, TokenStreamExt};
-use yaml_rust::Yaml;
+use serde_yaml::Value;
 
 pub struct IsTrue {
     pub(crate) expr: Expr,
@@ -46,7 +46,7 @@ impl From<IsTrue> for Step {
 }
 
 impl IsTrue {
-    pub fn try_parse(yaml: &Yaml) -> anyhow::Result<IsTrue> {
+    pub fn try_parse(yaml: &Value) -> anyhow::Result<IsTrue> {
         let expr = yaml
             .as_str()
             .ok_or_else(|| anyhow!("expected string key but found {:?}", &yaml))?;

--- a/yaml_test_runner/src/step/length.rs
+++ b/yaml_test_runner/src/step/length.rs
@@ -33,7 +33,7 @@ use crate::step::Expr;
 use anyhow::anyhow;
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens, TokenStreamExt};
-use yaml_rust::Yaml;
+use serde_yaml::Value;
 
 pub struct Length {
     pub(crate) expr: Expr,
@@ -47,9 +47,9 @@ impl From<Length> for Step {
 }
 
 impl Length {
-    pub fn try_parse(yaml: &Yaml) -> anyhow::Result<Length> {
+    pub fn try_parse(yaml: &Value) -> anyhow::Result<Length> {
         let hash = yaml
-            .as_hash()
+            .as_mapping()
             .ok_or_else(|| anyhow!("expected hash but found {:?}", yaml))?;
 
         let (k, v) = hash.iter().next().unwrap();

--- a/yaml_test_runner/src/step/set.rs
+++ b/yaml_test_runner/src/step/set.rs
@@ -33,7 +33,7 @@ use crate::step::Expr;
 use anyhow::anyhow;
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens, TokenStreamExt};
-use yaml_rust::Yaml;
+use serde_yaml::Value;
 
 pub struct Set {
     ident: syn::Ident,
@@ -47,9 +47,9 @@ impl From<Set> for Step {
 }
 
 impl Set {
-    pub fn try_parse(yaml: &Yaml) -> anyhow::Result<Set> {
+    pub fn try_parse(yaml: &Value) -> anyhow::Result<Set> {
         let hash = yaml
-            .as_hash()
+            .as_mapping()
             .ok_or_else(|| anyhow!("expected hash but found {:?}", yaml))?;
 
         let (k, v) = hash.iter().next().unwrap();

--- a/yaml_test_runner/src/step/skip.rs
+++ b/yaml_test_runner/src/step/skip.rs
@@ -33,7 +33,7 @@ use crate::skip::SkippedFeaturesAndTests;
 use super::Step;
 use lazy_static::lazy_static;
 use regex::Regex;
-use yaml_rust::Yaml;
+use serde_yaml::Value;
 
 pub struct Skip {
     version_requirements: Option<semver::VersionReq>,
@@ -104,7 +104,7 @@ impl Skip {
         }
     }
 
-    pub fn try_parse(yaml: &Yaml) -> anyhow::Result<Skip> {
+    pub fn try_parse(yaml: &Value) -> anyhow::Result<Skip> {
         let version = yaml["version"]
             .as_str()
             .map_or_else(|| None, |y| Some(y.to_string()));
@@ -112,8 +112,8 @@ impl Skip {
             .as_str()
             .map_or_else(|| None, |y| Some(y.to_string()));
         let features = match &yaml["features"] {
-            Yaml::String(s) => Some(vec![s.to_string()]),
-            Yaml::Array(a) => Some(
+            Value::String(s) => Some(vec![s.to_string()]),
+            Value::Sequence(a) => Some(
                 a.iter()
                     .map(|y| y.as_str().map(|s| s.to_string()).unwrap())
                     .collect(),

--- a/yaml_test_runner/src/step/transform_and_set.rs
+++ b/yaml_test_runner/src/step/transform_and_set.rs
@@ -34,8 +34,8 @@ use anyhow::anyhow;
 use inflector::Inflector;
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens, TokenStreamExt};
+use serde_yaml::Value;
 use syn::parse_quote;
-use yaml_rust::Yaml;
 
 pub struct Transformation {
     #[allow(dead_code)]
@@ -100,9 +100,9 @@ impl From<TransformAndSet> for Step {
 }
 
 impl TransformAndSet {
-    pub fn try_parse(yaml: &Yaml) -> anyhow::Result<TransformAndSet> {
+    pub fn try_parse(yaml: &Value) -> anyhow::Result<TransformAndSet> {
         let hash = yaml
-            .as_hash()
+            .as_mapping()
             .ok_or_else(|| anyhow!("expected hash but found {:?}", yaml))?;
 
         let (k, v) = hash.iter().next().unwrap();


### PR DESCRIPTION
### Description
Replaces usages of yaml-rust with serde_yaml, avoids mixing of YAML parsers as well as being more actively maintained and has integration with serde ecosystem. Also now successfully parses at least one more YAML test case that yaml-rust was failing on, but currently needs to be ignored due to issue with numeric indexing of JSON objects.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
