### PR TITLE
Remove aditjind from CODEOWNERS due to their permissions currently being inactive

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @dblock @Xtansia @VachaShah @aditjind @reta
+*   @dblock @Xtansia @VachaShah @reta


### PR DESCRIPTION
### Description
Removes aditjind from CODEOWNERS due to their permissions currently being inactive.
This is currently causing an issue with the one-click release workflow approval step: https://github.com/opensearch-project/opensearch-rs/actions/runs/4803532526/jobs/8548110084#step:5:34
This does not revoke their maintainer status, so at such a time they become active again and their permissions are restored they can be re-added to CODEOWNERS for being auto-assigned to reviews.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
