### PR TITLE
Fixes YAML spec tests by adding u64 (unsigned long) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Fixes `cargo make test` failing out of the box ([#117](https://github.com/opensearch-project/opensearch-rs/pull/117))
 - Fixes f64 comparison in `yaml_test_runner` to use numeric-based comparison instead of string-based ([#150](https://github.com/opensearch-project/opensearch-rs/pull/150))
+- Fixes YAML spec tests by adding u64 (unsigned long) support ([#167](https://github.com/opensearch-project/opensearch-rs/pull/167))
 
 ### Security
 

--- a/yaml_test_runner/src/step/do.rs
+++ b/yaml_test_runner/src/step/do.rs
@@ -859,7 +859,7 @@ impl ApiCall {
             Value::String(s) => {
                 let json = {
                     let json = replace_set(s);
-                    replace_i64(json)
+                    replace_i64_u64(json)
                 };
                 if endpoint.supports_nd_body() {
                     // a newline delimited API body may be expressed
@@ -896,7 +896,7 @@ impl ApiCall {
                             syn::parse_str::<TokenStream>(&json).unwrap()
                         } else {
                             json = replace_set(json);
-                            json = replace_i64(json);
+                            json = replace_i64_u64(json);
                             let json = syn::parse_str::<TokenStream>(&json).unwrap();
                             quote!(JsonBody::from(json!(#json)))
                         }
@@ -905,7 +905,7 @@ impl ApiCall {
                 } else {
                     let mut json = serde_json::to_string_pretty(&v)?;
                     json = replace_set(json);
-                    json = replace_i64(json);
+                    json = replace_i64_u64(json);
                     let ident: TokenStream = syn::parse_str(&json).unwrap();
 
                     Ok(Some(quote!(.body(json!{#ident}))))

--- a/yaml_test_runner/src/step/match.rs
+++ b/yaml_test_runner/src/step/match.rs
@@ -112,6 +112,15 @@ impl ToTokens for Match {
                             crate::assert_numeric_match!(json#expr, #f);
                         });
                     }
+                } else if i.is_u64() {
+                    let ui = i.as_u64().unwrap();
+                    if self.expr.is_body() {
+                        panic!("match on $body with u64");
+                    } else {
+                        tokens.append_all(quote! {
+                            crate::assert_numeric_match!(json#expr, #ui);
+                        });
+                    }
                 } else {
                     let i = i.as_i64().unwrap();
                     if self.expr.is_body() {

--- a/yaml_test_runner/src/step/mod.rs
+++ b/yaml_test_runner/src/step/mod.rs
@@ -253,6 +253,6 @@ pub fn ok_or_accumulate<T>(results: &[anyhow::Result<T>]) -> anyhow::Result<()> 
 pub fn json_string_from_yaml(yaml: &Value) -> String {
     let mut json = serde_json::to_string(yaml).unwrap();
     json = replace_set(json);
-    json = replace_i64(json);
+    json = replace_i64_u64(json);
     json
 }


### PR DESCRIPTION
### Description
Fix YAML spec tests by adding u64 (unsigned long) support

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
