### PR TITLE
Fix CI YAML Tests

### DIFF
--- a/opensearch/examples/advanced_index_actions.rs
+++ b/opensearch/examples/advanced_index_actions.rs
@@ -19,11 +19,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let url = Url::parse("https://localhost:9200")?;
     let credentials = Credentials::Basic("admin".into(), "admin".into());
     let transport = TransportBuilder::new(SingleNodeConnectionPool::new(url))
-          .cert_validation(CertificateValidation::None)
-          .auth(credentials)
-          .build()?;
+        .cert_validation(CertificateValidation::None)
+        .auth(credentials)
+        .build()?;
     let client = OpenSearch::new(transport);
-    
+
     client
         .indices()
         .create(IndicesCreateParts::Index("movies"))
@@ -108,7 +108,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }))
         .send()
         .await?;
-      
+
     // You can split an index into another index with more primary shards. The source index must be in read-only state for splitting. The following example creates the read-only `books` index with 30 routing shards and 5 shards (which 30 is divisible by), splits the index into `bigger_books` with 10 shards (which 30 is also divisible by), then re-enables writes:
     client
         .indices()
@@ -138,7 +138,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .body(json!({"index": {"blocks": {"write": false}}}))
         .send()
         .await?;
-      
+
     // Let's delete all the indices we created in this guide:
     client
         .indices()

--- a/yaml_test_runner/Cargo.toml
+++ b/yaml_test_runner/Cargo.toml
@@ -28,7 +28,7 @@ reqwest = { version = "~0.11", features = ["blocking"] }
 semver = "1.0"
 serde = "~1"
 serde_yaml = "0.9"
-serde_json = { version = "~1" }
+serde_json = { version = "~1", features = ["arbitrary_precision"] }
 simple_logger = "4.0.0"
 syn = { version = "~1.0", features = ["full"] }
 sysinfo = "0.28"

--- a/yaml_test_runner/Cargo.toml
+++ b/yaml_test_runner/Cargo.toml
@@ -28,7 +28,7 @@ reqwest = { version = "~0.11", features = ["blocking"] }
 semver = "1.0"
 serde = "~1"
 serde_yaml = "0.9"
-serde_json = { version = "~1", features = ["arbitrary_precision"] }
+serde_json = { version = "~1" }
 simple_logger = "4.0.0"
 syn = { version = "~1.0", features = ["full"] }
 sysinfo = "0.28"

--- a/yaml_test_runner/skip.yml
+++ b/yaml_test_runner/skip.yml
@@ -7,10 +7,20 @@
     free/cat.aliases/10_basic.yml:
       # this test fails as the regex needs a \n before the ending $
       - Multiple alias names
-    free/cat.templates/10_basic.yml:
-      # Regex do not account for hidden templates returned by the request 
-      - No templates
     free/cluster.health/10_basic.yml:
       - cluster health with closed index (pre 7.2.0)
     free/cluster.put_settings/10_basic.yml:
       - Test put and reset persistent settings
+
+"<1.3.0":
+  tests:
+    free/search/10_source_filtering.yml:
+      - "docvalue_fields with default format"
+    free/search.aggregation/250_moving_fn.yml:
+      - "Bad window deprecated interval"
+
+"<2.4.0":
+  tests:
+    free/scripts/25_get_script_languages.yml:
+      - "Action to get script languages"
+    

--- a/yaml_test_runner/src/generator.rs
+++ b/yaml_test_runner/src/generator.rs
@@ -93,7 +93,7 @@ impl<'a> YamlTests<'a> {
     fn use_directives_from_steps(steps: &[Step]) -> Vec<String> {
         steps
             .iter()
-            .filter_map(Step::r#do)
+            .filter_map(Step::as_do)
             .filter_map(|d| d.namespace())
             .map(|s| s.to_string())
             .collect()
@@ -185,6 +185,37 @@ impl<'a> YamlTests<'a> {
         self.skip.should_skip_test(&self.path, name)
     }
 
+    fn skip_reason(&self, s: &Skip) -> Option<String> {
+        if s.skip_version(self.version) {
+            Some(format!(
+                "version \"{}\" is met. {}",
+                s.version(),
+                s.reason()
+            ))
+        } else if s.skip_features(self.skip) {
+            Some(format!(
+                "it needs features \"{:?}\" which are currently not implemented",
+                s.features()
+            ))
+        } else {
+            None
+        }
+    }
+
+    fn should_skip_suite(&self) -> Option<String> {
+        if self.should_skip_test("*") {
+            Some(format!("it's included in skip.yml"))
+        } else if let Some(setup) = &self.setup {
+            setup
+                .steps
+                .iter()
+                .filter_map(Step::as_skip)
+                .find_map(|s| self.skip_reason(s))
+        } else {
+            None
+        }
+    }
+
     fn fn_impls(
         &self,
         general_setup_call: TokenStream,
@@ -201,46 +232,26 @@ impl<'a> YamlTests<'a> {
                 if self.should_skip_test(name) {
                     info!(
                         r#"skipping "{}" in {} because it's included in skip.yml"#,
-                        name,
-                        self.path,
+                        name, self.path,
                     );
                     return None;
                 }
 
                 let fn_name = syn::Ident::new(unique_name.as_str(), Span::call_site());
                 let mut body = TokenStream::new();
-                let mut skip : Option<String> = None;
+                let mut skip: Option<String> = None;
                 let mut read_response = false;
 
                 for step in &test_fn.steps {
                     match step {
                         Step::Skip(s) => {
-                            skip = if s.skip_version(self.version) {
-                                let m = format!(
-                                    r#"skipping "{}" in {} because version "{}" is met. {}"#,
-                                    name,
-                                    &self.path,
-                                    s.version(),
-                                    s.reason()
-                                );
-                                Some(m)
-                            } else if s.skip_features(self.skip) {
-                                let m = format!(
-                                    r#"skipping "{}" in {} because it needs features "{:?}" which are currently not implemented"#,
-                                    name,
-                                    &self.path,
-                                    s.features()
-                                );
-                                Some(m)
-                            } else {
-                                None
-                            }
+                            skip = self.skip_reason(s);
                         }
                         Step::Do(d) => {
                             read_response = d.to_tokens(false, &mut body);
                         }
                         Step::Match(m) => {
-                            read_response = Self::read_response(read_response,&mut body);
+                            read_response = Self::read_response(read_response, &mut body);
                             m.to_tokens(&mut body);
                         }
                         Step::Set(s) => {
@@ -248,27 +259,27 @@ impl<'a> YamlTests<'a> {
                             s.to_tokens(&mut body);
                         }
                         Step::Length(l) => {
-                            read_response = Self::read_response(read_response,&mut body);
+                            read_response = Self::read_response(read_response, &mut body);
                             l.to_tokens(&mut body);
-                        },
+                        }
                         Step::IsTrue(t) => {
-                            read_response = Self::read_response(read_response,&mut body);
+                            read_response = Self::read_response(read_response, &mut body);
                             t.to_tokens(&mut body);
-                        },
+                        }
                         Step::IsFalse(f) => {
                             read_response = Self::read_response(read_response, &mut body);
                             f.to_tokens(&mut body);
-                        },
+                        }
                         Step::Comparison(c) => {
-                            read_response = Self::read_response(read_response,&mut body);
+                            read_response = Self::read_response(read_response, &mut body);
                             c.to_tokens(&mut body);
-                        },
+                        }
                         Step::Contains(c) => {
-                            read_response = Self::read_response(read_response,&mut body);
+                            read_response = Self::read_response(read_response, &mut body);
                             c.to_tokens(&mut body);
-                        },
+                        }
                         Step::TransformAndSet(t) => {
-                            read_response = Self::read_response(read_response,&mut body);
+                            read_response = Self::read_response(read_response, &mut body);
                             t.to_tokens(&mut body);
                         }
                     }
@@ -276,9 +287,9 @@ impl<'a> YamlTests<'a> {
 
                 match skip {
                     Some(s) => {
-                        info!("{}", s);
+                        info!("skipping \"{}\" in {} because: {}", name, self.path, s);
                         None
-                    },
+                    }
                     None => Some(quote! {
                         #[tokio::test]
                         async fn #fn_name() -> anyhow::Result<()> {
@@ -304,7 +315,7 @@ impl<'a> YamlTests<'a> {
             let tokens = t
                 .steps
                 .iter()
-                .filter_map(Step::r#do)
+                .filter_map(Step::as_do)
                 .map(|d| {
                     let mut tokens = TokenStream::new();
                     ToTokens::to_tokens(d, &mut tokens);
@@ -526,11 +537,8 @@ fn write_test_file(
     relative_path: &Path,
     generated_dir: &Path,
 ) -> anyhow::Result<()> {
-    if test.should_skip_test("*") {
-        info!(
-            r#"skipping all tests in {} because it's included in skip.yml"#,
-            test.path,
-        );
+    if let Some(reason) = test.should_skip_suite() {
+        info!("skipping all tests in {} because: {}", test.path, reason);
         return Ok(());
     }
 

--- a/yaml_test_runner/src/main.rs
+++ b/yaml_test_runner/src/main.rs
@@ -43,6 +43,7 @@ use std::{
 mod generator;
 mod github;
 mod regex;
+mod rusty_json;
 mod skip;
 mod step;
 

--- a/yaml_test_runner/src/main.rs
+++ b/yaml_test_runner/src/main.rs
@@ -158,7 +158,10 @@ fn branch_suite_and_version_from_opensearch(
 
     let response = client.get(url).basic_auth("admin", Some("admin")).send()?;
     let json: Value = response.json()?;
-    let branch = json["version"]["build_hash"].as_str().unwrap().to_string();
+    let branch = match json["version"]["build_hash"].as_str() {
+        Some(build_hash) if build_hash != "unknown" => build_hash.to_string(),
+        _ => "main".to_string(),
+    };
 
     // any prerelease part needs to be trimmed because the semver crate only allows
     // a version with a prerelease to match against predicates, if at least one predicate

--- a/yaml_test_runner/src/regex.rs
+++ b/yaml_test_runner/src/regex.rs
@@ -28,7 +28,7 @@
  * GitHub history for details.
  */
 
-use ::regex::{Captures, Regex};
+use ::regex::Regex;
 use lazy_static::lazy_static;
 
 lazy_static! {
@@ -43,12 +43,6 @@ lazy_static! {
     // replace usages of ${.*} with the captured value
     pub static ref SET_DELIMITED_REGEX: Regex =
         Regex::new(r#"\$\{(.*?)\}"#).unwrap();
-
-    // include i64 suffix on whole numbers larger than i32
-    // will match on numbers with 10 or more digits, with the replace
-    // call testing against i32::max_value
-    pub static ref INT_REGEX: Regex =
-        regex::Regex::new(r"([,:\[{]\s*[-]?)(\d{10,}?)(\s*[,}\]])").unwrap();
 }
 
 /// cleans up a regex as specified in YAML to one that will work with the regex crate.
@@ -75,23 +69,4 @@ pub fn replace_set<S: AsRef<str>>(s: S) -> String {
         .into_owned();
 
     SET_REGEX.replace_all(s.as_ref(), "$1").into_owned()
-}
-
-/// Replaces all integers in a string to suffix with i64, to ensure that numbers
-/// larger than i32 will be handled correctly when passed to json! macro
-pub fn replace_i64_u64<S: AsRef<str>>(s: S) -> String {
-    INT_REGEX
-        .replace_all(s.as_ref(), |c: &Captures| match &c[2].parse::<i128>() {
-            Ok(i) if *i < i32::min_value() as i128 => {
-                format!("{}{}i64{}", &c[1], &c[2], &c[3])
-            }
-            Ok(i) if *i > i32::max_value() as i128 && *i <= i64::max_value() as i128 => {
-                format!("{}{}i64{}", &c[1], &c[2], &c[3])
-            }
-            Ok(i) if *i > i64::max_value() as i128 && *i <= u64::max_value() as i128 => {
-                format!("{}{}u64{}", &c[1], &c[2], &c[3])
-            }
-            _ => c[0].to_string(),
-        })
-        .into_owned()
 }

--- a/yaml_test_runner/src/regex.rs
+++ b/yaml_test_runner/src/regex.rs
@@ -28,23 +28,6 @@
  * GitHub history for details.
  */
 
-use ::regex::Regex;
-use lazy_static::lazy_static;
-
-lazy_static! {
-    // replace usages of "$.*" with the captured value
-    pub static ref SET_REGEX: Regex =
-        Regex::new(r#""\$(.*?)""#).unwrap();
-
-    // replace usages of "${.*}" with the captured value
-    pub static ref SET_QUOTED_DELIMITED_REGEX: Regex =
-        Regex::new(r#""\$\{(.*?)\}""#).unwrap();
-
-    // replace usages of ${.*} with the captured value
-    pub static ref SET_DELIMITED_REGEX: Regex =
-        Regex::new(r#"\$\{(.*?)\}"#).unwrap();
-}
-
 /// cleans up a regex as specified in YAML to one that will work with the regex crate.
 pub fn clean_regex<S: AsRef<str>>(s: S) -> String {
     s.as_ref()
@@ -56,17 +39,4 @@ pub fn clean_regex<S: AsRef<str>>(s: S) -> String {
         .replace("\\%", "%")
         .replace("\\'", "'")
         .replace("\\`", "`")
-}
-
-/// Replaces a "set" step value with a variable
-pub fn replace_set<S: AsRef<str>>(s: S) -> String {
-    let mut s = SET_QUOTED_DELIMITED_REGEX
-        .replace_all(s.as_ref(), "$1")
-        .into_owned();
-
-    s = SET_DELIMITED_REGEX
-        .replace_all(s.as_ref(), "$1")
-        .into_owned();
-
-    SET_REGEX.replace_all(s.as_ref(), "$1").into_owned()
 }

--- a/yaml_test_runner/src/rusty_json.rs
+++ b/yaml_test_runner/src/rusty_json.rs
@@ -1,0 +1,42 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use serde_yaml::Value;
+
+pub fn rusty_json(v: &Value) -> TokenStream {
+    match v {
+        Value::Null => quote! { serde_json::Value::Null },
+        Value::Bool(b) => quote! { #b },
+        Value::Number(n) => {
+            if n.is_f64() {
+                let f = n.as_f64().unwrap();
+                quote! { #f }
+            } else if n.is_i64() {
+                let i = n.as_i64().unwrap();
+                quote! { #i }
+            } else {
+                let u = n.as_u64().unwrap();
+                quote! { #u }
+            }
+        }
+        Value::String(s) => {
+            quote! { #s }
+        }
+        Value::Mapping(m) => {
+            let kvs = m.iter().map(|(k, v)| {
+                let k = match k {
+                    Value::String(s) => s.clone(),
+                    Value::Number(n) => n.to_string(),
+                    _ => panic!("unsupported key {:?}", k),
+                };
+                let v = rusty_json(v);
+                quote! { #k: #v }
+            });
+            quote! { { #(#kvs),* } }
+        }
+        Value::Sequence(s) => {
+            let items = s.iter().map(rusty_json);
+            quote! { [#(#items),*] }
+        }
+        _ => panic!("unsupported value {:?}", v),
+    }
+}

--- a/yaml_test_runner/src/rusty_json.rs
+++ b/yaml_test_runner/src/rusty_json.rs
@@ -75,8 +75,8 @@ pub fn rusty_json(v: &Value) -> TokenStream {
 
 #[cfg(test)]
 mod test {
-    use quote::quote;
     use super::from_set_value;
+    use quote::quote;
 
     #[test]
     fn from_set_value_correctly_interpolates_strings() {

--- a/yaml_test_runner/src/step/contains.rs
+++ b/yaml_test_runner/src/step/contains.rs
@@ -29,7 +29,7 @@
  */
 
 use super::Step;
-use crate::step::{json_string_from_yaml, Expr};
+use crate::{rusty_json::rusty_json, step::Expr};
 use anyhow::anyhow;
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens, TokenStreamExt};
@@ -70,35 +70,35 @@ impl ToTokens for Contains {
                 if n.is_f64() {
                     let f = n.as_f64().unwrap();
                     tokens.append_all(quote! {
-                        assert_contains!(json#expr, json!(#f));
+                        crate::assert_contains!(json#expr, json!(#f));
                     });
                 } else if n.is_u64() {
                     let u = n.as_u64().unwrap();
                     tokens.append_all(quote! {
-                        assert_contains!(json#expr, json!(#u));
+                        crate::assert_contains!(json#expr, json!(#u));
                     });
                 } else {
                     let i = n.as_i64().unwrap();
                     tokens.append_all(quote! {
-                        assert_contains!(json#expr, json!(#i));
+                        crate::assert_contains!(json#expr, json!(#i));
                     });
                 }
             }
             Value::String(s) => {
                 tokens.append_all(quote! {
-                    assert_contains!(json#expr, json!(#s));
+                    crate::assert_contains!(json#expr, json!(#s));
                 });
             }
             Value::Bool(b) => {
                 tokens.append_all(quote! {
-                    assert_contains!(json#expr, json!(#b));
+                    crate::assert_contains!(json#expr, json!(#b));
                 });
             }
             yaml if yaml.is_sequence() || yaml.is_mapping() => {
-                let json = syn::parse_str::<TokenStream>(&json_string_from_yaml(yaml)).unwrap();
+                let json = rusty_json(yaml);
 
                 tokens.append_all(quote! {
-                    assert_contains!(json#expr, json!(#json));
+                    crate::assert_contains!(json#expr, json!(#json));
                 });
             }
             yaml => {

--- a/yaml_test_runner/src/step/do.rs
+++ b/yaml_test_runner/src/step/do.rs
@@ -31,7 +31,7 @@
 use super::{ResultIterExt, Step};
 use crate::{
     regex::clean_regex,
-    rusty_json::{rusty_json, from_set_value},
+    rusty_json::{from_set_value, rusty_json},
 };
 use anyhow::anyhow;
 use api_generator::generator::{Api, ApiEndpoint, TypeKind};

--- a/yaml_test_runner/src/step/mod.rs
+++ b/yaml_test_runner/src/step/mod.rs
@@ -30,6 +30,7 @@
 
 use anyhow::anyhow;
 use api_generator::generator::Api;
+use itertools::Itertools;
 use proc_macro2::TokenStream;
 use serde_yaml::Value;
 use std::fmt::Write;
@@ -232,19 +233,19 @@ impl Step {
     }
 }
 
-/// Checks whether there are any Errs in the collection, and accumulates them into one
-/// error message if there are.
-pub fn ok_or_accumulate<T>(results: &[anyhow::Result<T>]) -> anyhow::Result<()> {
-    let errs = results
-        .iter()
-        .filter_map(|r| r.as_ref().err())
-        .collect::<Vec<_>>();
-    if errs.is_empty() {
-        Ok(())
-    } else {
-        let mut msgs = errs.iter().map(|e| e.to_string()).collect::<Vec<_>>();
-        msgs.sort();
-        msgs.dedup_by(|a, b| a == b);
-        Err(anyhow!("{}", msgs.join(", ")))
+pub trait ResultIterExt<T> : Iterator<Item = anyhow::Result<T>> + Sized {
+    fn collect_results(self) -> anyhow::Result<Vec<T>> {
+        let (oks, errs): (Vec<_>, Vec<_>) = self.partition_result();
+
+        if errs.is_empty() {
+            Ok(oks)
+        } else {
+            let mut msgs = errs.iter().map(|e| e.to_string()).collect::<Vec<_>>();
+            msgs.sort();
+            msgs.dedup_by(|a, b| a == b);
+            Err(anyhow!("{}", msgs.join(", ")))
+        }
     }
 }
+
+impl<T, I> ResultIterExt<T> for I where I: Iterator<Item = anyhow::Result<T>> + Sized {}

--- a/yaml_test_runner/src/step/mod.rs
+++ b/yaml_test_runner/src/step/mod.rs
@@ -28,7 +28,6 @@
  * GitHub history for details.
  */
 
-use crate::regex::*;
 use anyhow::anyhow;
 use api_generator::generator::Api;
 use proc_macro2::TokenStream;
@@ -248,11 +247,4 @@ pub fn ok_or_accumulate<T>(results: &[anyhow::Result<T>]) -> anyhow::Result<()> 
         msgs.dedup_by(|a, b| a == b);
         Err(anyhow!("{}", msgs.join(", ")))
     }
-}
-
-pub fn json_string_from_yaml(yaml: &Value) -> String {
-    let mut json = serde_json::to_string(yaml).unwrap();
-    json = replace_set(json);
-    json = replace_i64_u64(json);
-    json
 }

--- a/yaml_test_runner/src/step/mod.rs
+++ b/yaml_test_runner/src/step/mod.rs
@@ -225,15 +225,22 @@ pub enum Step {
 
 impl Step {
     /// Gets a Do step
-    pub fn r#do(&self) -> Option<&Do> {
+    pub fn as_do(&self) -> Option<&Do> {
         match self {
             Step::Do(d) => Some(d),
             _ => None,
         }
     }
+
+    pub fn as_skip(&self) -> Option<&Skip> {
+        match self {
+            Step::Skip(s) => Some(s),
+            _ => None,
+        }
+    }
 }
 
-pub trait ResultIterExt<T> : Iterator<Item = anyhow::Result<T>> + Sized {
+pub trait ResultIterExt<T>: Iterator<Item = anyhow::Result<T>> + Sized {
     fn collect_results(self) -> anyhow::Result<Vec<T>> {
         let (oks, errs): (Vec<_>, Vec<_>) = self.partition_result();
 

--- a/yaml_test_runner/tests/common/client.rs
+++ b/yaml_test_runner/tests/common/client.rs
@@ -38,7 +38,7 @@ use opensearch::{
         transport::{SingleNodeConnectionPool, TransportBuilder},
         Method, StatusCode,
     },
-    indices::{IndicesDeleteParts, IndicesDeleteTemplateParts, IndicesDeleteIndexTemplateParts},
+    indices::{IndicesDeleteIndexTemplateParts, IndicesDeleteParts, IndicesDeleteTemplateParts},
     params::ExpandWildcards,
     snapshot::{SnapshotDeleteParts, SnapshotDeleteRepositoryParts},
     Error, OpenSearch, DEFAULT_ADDRESS,

--- a/yaml_test_runner/tests/common/client.rs
+++ b/yaml_test_runner/tests/common/client.rs
@@ -32,12 +32,13 @@ use once_cell::sync::Lazy;
 use opensearch::{
     auth::{ClientCertificate, Credentials},
     cert::CertificateValidation,
+    cluster::ClusterDeleteComponentTemplateParts,
     http::{
         response::Response,
         transport::{SingleNodeConnectionPool, TransportBuilder},
         Method, StatusCode,
     },
-    indices::IndicesDeleteParts,
+    indices::{IndicesDeleteParts, IndicesDeleteTemplateParts, IndicesDeleteIndexTemplateParts},
     params::ExpandWildcards,
     snapshot::{SnapshotDeleteParts, SnapshotDeleteRepositoryParts},
     Error, OpenSearch, DEFAULT_ADDRESS,
@@ -125,6 +126,7 @@ pub async fn general_cluster_setup() -> Result<(), Error> {
     let client = get();
     delete_indices(client).await?;
     delete_snapshots(client).await?;
+    delete_templates(client).await?;
 
     Ok(())
 }
@@ -180,5 +182,33 @@ async fn delete_indices(client: &OpenSearch) -> Result<(), Error> {
         .await?;
 
     assert_response_success!(delete_response);
+    Ok(())
+}
+
+async fn delete_templates(client: &OpenSearch) -> Result<(), Error> {
+    let delete_response = client
+        .indices()
+        .delete_template(IndicesDeleteTemplateParts::Name("*"))
+        .send()
+        .await?;
+
+    assert_response_success!(delete_response);
+
+    let delete_response = client
+        .indices()
+        .delete_index_template(IndicesDeleteIndexTemplateParts::Name("*"))
+        .send()
+        .await?;
+
+    assert_response_success!(delete_response);
+
+    let delete_response = client
+        .cluster()
+        .delete_component_template(ClusterDeleteComponentTemplateParts::Name("*"))
+        .send()
+        .await?;
+
+    assert_response_success!(delete_response);
+
     Ok(())
 }


### PR DESCRIPTION
### Description
This fixes several issues with the YAML tests, including those that are currently failing due to the new unsigned data type. This improves the mechanism by which we convert the request bodies into the `json! {}` macro, so that we can avoid doing RegEx replaces on JSON strings. It also adds a hack for the version skip logic due to OS versions "resetting" to "1.0" that meant many test cases were being ignored as they were for ES >= 7.0. Additionally adding logic to cleanup index templates in test teardown so that some of the now running tests pass.
This results in ~300-400 extra test cases now running and passing. (Previously ~800 cases, now ~1200 cases)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
