### PR TITLE
Moved @aditjind to emeritus.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
+# This list should match MAINTAINERS.md. 
 *   @dblock @Xtansia @VachaShah @reta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Dependencies
 
 ### Changed
+- Moved @aditjind to Emeritus maintainers ([#170](https://github.com/opensearch-project/opensearch-rs/pull/170))
 
 ### Deprecated
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,5 +9,10 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Daniel Doubrovkine | [dblock](https://github.com/dblock)       | Amazon      |
 | Thomas Farr        | [Xtansia](https://github.com/Xtansia)     | Amazon      |
 | Vacha Shah         | [VachaShah](https://github.com/VachaShah) | Amazon      |
-| Aditya Jindal      | [aditjind](https://github.com/aditjind)   | aditjind    |
 | Andriy Redko       | [reta](https://github.com/reta)           | Aiven       |
+
+## Emeritus
+
+| Maintainer    | GitHub ID                               | Affiliation |
+| ------------- | --------------------------------------- | ----------- |
+| Aditya Jindal | [aditjind](https://github.com/aditjind) | Amazon      |


### PR DESCRIPTION
### Description

~Coming from https://github.com/opensearch-project/opensearch-rs/pull/169, re-added @aditjind to CODEOWNERS until they express the desire not to be a maintainer anymore.~

Moved maintainer to emeritus due to inactivity.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
