### PR TITLE
Fix scheduled testing issue template path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -190,5 +190,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.github_app_token.outputs.token }}
         with:
-          filename: .github/test-failure-issue-template.md
+          filename: ./client/.github/test-failure-issue-template.md
           update_existing: true


### PR DESCRIPTION
### Description
I'd forgotten to prefix the issue template path as the client source gets checked out into the `client` subfolder.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
