### PR TITLE
Avoid using custom version requirements

### DIFF
--- a/api_generator/Cargo.toml
+++ b/api_generator/Cargo.toml
@@ -12,24 +12,24 @@ license = "Apache-2.0"
 anyhow = "1.0"
 array_tool = "1.0.3"
 dialoguer = "0.10.2"
-flate2 = "~1"
-globset = "~0.4"
+flate2 = "1"
+globset = "0.4"
 Inflector = "0.11.4"
 itertools = "0.11.0"
 lazy_static = "1.4.0"
 log = "0.4.8"
 path-slash = "0.2.1"
-proc-macro2 = "~1.0"
-quote = "~1.0"
+proc-macro2 = "1.0"
+quote = "1.0"
 reduce = "0.1.2"
 regex = "1.3.1"
-reqwest = { version = "~0.11", features = ["blocking"] }
+reqwest = { version = "0.11", features = ["blocking"] }
 semver = "1.0.14"
-serde = { version = "~1", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
 serde_json = "~1"
 simple_logger = "4.0.0"
-syn = { version = "~2.0", features = ["extra-traits", "full"] }
-tar = "~0.4"
+syn = { version = "2.0", features = ["extra-traits", "full"] }
+tar = "0.4"
 toml = "0.7.1"
 url = "2.1.1"
 void = "1.0.2"

--- a/opensearch/Cargo.toml
+++ b/opensearch/Cargo.toml
@@ -29,34 +29,34 @@ rustls-tls = ["reqwest/rustls-tls"]
 aws-auth = ["aws-credential-types", "aws-sigv4", "aws-types"]
 
 [dependencies]
-base64 = "^0.21"
-bytes = "^1.0"
-dyn-clone = "~1"
+base64 = "0.21"
+bytes = "1.0"
+dyn-clone = "1"
 lazy_static = "1.4"
 percent-encoding = "2.1.0"
-reqwest = { version = "~0.11", default-features = false, features = ["gzip", "json"] }
-url = "^2.1"
-serde = { version = "~1", features = ["derive"] }
-serde_json = "~1"
-serde_with = "~3"
+reqwest = { version = "0.11", default-features = false, features = ["gzip", "json"] }
+url = "2.1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_with = "3"
 void = "1.0.2"
-aws-credential-types = { version = ">= 0.53", optional = true }
-aws-sigv4 = { version = ">= 0.53", optional = true }
-aws-types = { version = ">= 0.53", optional = true }
+aws-credential-types = { version = "0.53", optional = true }
+aws-sigv4 = { version = "0.53", optional = true }
+aws-types = { version = "0.53", optional = true }
 
 [dev-dependencies]
 anyhow = "1.0"
-aws-config = ">= 0.53"
-chrono = { version = "^0.4", features = ["serde"] }
-clap = "~2"
+aws-config = "0.53"
+chrono = { version = "0.4", features = ["serde"] }
+clap = "2"
 futures = "0.3.1"
 http = "0.2"
 hyper = { version = "0.14", default-features = false, features = ["tcp", "stream", "server"] }
 regex="1.4"
 sysinfo = "0.29.0"
-textwrap = "^0.16"
+textwrap = "0.16"
 tokio = { version = "1.0", default-features = false, features = ["macros", "net", "time", "rt-multi-thread"] }
-xml-rs = "^0.8"
+xml-rs = "0.8"
 
 [build-dependencies]
 rustc_version = "0.4"

--- a/opensearch/Cargo.toml
+++ b/opensearch/Cargo.toml
@@ -40,13 +40,13 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_with = "3"
 void = "1.0.2"
-aws-credential-types = { version = "0.53", optional = true }
-aws-sigv4 = { version = "0.53", optional = true }
-aws-types = { version = "0.53", optional = true }
+aws-credential-types = { version = ">= 0.53", optional = true }
+aws-sigv4 = { version = ">= 0.53", optional = true }
+aws-types = { version = ">= 0.53", optional = true }
 
 [dev-dependencies]
 anyhow = "1.0"
-aws-config = "0.53"
+aws-config = ">= 0.53"
 chrono = { version = "0.4", features = ["serde"] }
 clap = "2"
 futures = "0.3.1"

--- a/yaml_test_runner/Cargo.toml
+++ b/yaml_test_runner/Cargo.toml
@@ -13,29 +13,29 @@ opensearch = { path = "../opensearch", features = ["experimental-apis"]}
 api_generator = { path = "./../api_generator" }
 
 anyhow = "1.0"
-base64 = "^0.21"
-clap = "~2"
+base64 = "0.21"
+clap = "2"
 itertools = "0.11.0"
 Inflector = "0.11.4"
 lazy_static = "1.4.0"
 log = "0.4.8"
 once_cell = "1.4.0"
 path-slash = "0.2"
-proc-macro2 = "~1.0"
-quote = "~1.0"
+proc-macro2 = "1.0"
+quote = "1.0"
 regex = "1.3.1"
-reqwest = { version = "~0.11", features = ["blocking"] }
+reqwest = { version = "0.11", features = ["blocking"] }
 semver = "1.0"
-serde = "~1"
+serde = "1"
 serde_yaml = "0.9"
-serde_json = { version = "~1", features = ["arbitrary_precision"] }
+serde_json = { version = "1", features = ["arbitrary_precision"] }
 simple_logger = "4.0.0"
-syn = { version = "~1.0", features = ["full"] }
+syn = { version = "1.0", features = ["full"] }
 sysinfo = "0.29"
 url = "2.1.1"
-tar = "~0.4"
-flate2 = "~1"
-globset = "~0.4"
+tar = "0.4"
+flate2 = "1"
+globset = "0.4"
 
 [dev-dependencies]
 tokio = { version = "1.0", default-features = false, features = ["macros", "net", "time"] }


### PR DESCRIPTION
Using custom version requirements in a library is generally considered a bad idea as it can lead to broken builds downstream.
The cargo docs [goes into this](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-requirements) in the box starting with:

> Recommendation: When in doubt, use the default version requirement operator.
> ...


In this PR I have removed all non-default version requirements.
Happy to discuss if you feel some are needed.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
