### PR TITLE
feature: add auto version bump after release

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -3,7 +3,7 @@ name: Increment Version
 on:
   push:
     tags:
-      - '*.*.*'
+      - 'v*.*.*'
 
 permissions: {}
 jobs:
@@ -22,14 +22,25 @@ jobs:
       - uses: actions/checkout@v4
       - name: Fetch and Update Version Information
         run: |
-          TAG=$(echo "${GITHUB_REF#refs/*/}")
+          TAG=$(echo "${GITHUB_REF#refs/*/v}")
           CURRENT_VERSION_ARRAY=($(echo "$TAG" | tr . '\n'))
+          BASE=$(IFS=. ; echo "${CURRENT_VERSION_ARRAY[*]:0:2}")
           CURRENT_VERSION=$(IFS=. ; echo "${CURRENT_VERSION_ARRAY[*]:0:3}")
           CURRENT_VERSION_ARRAY[2]=$((CURRENT_VERSION_ARRAY[2]+1))
           NEXT_VERSION=$(IFS=. ; echo "${CURRENT_VERSION_ARRAY[*]:0:3}")
           echo "TAG=$TAG" >> $GITHUB_ENV
           echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
           echo "NEXT_VERSION=$NEXT_VERSION" >> $GITHUB_ENV
+          echo "BASE=$BASE" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.BASE }}
+          token: ${{ steps.github_app_token.outputs.token }}
+
+      - name: Increment Patch Version
+        run: |
+          echo Incrementing $CURRENT_VERSION to $NEXT_VERSION
           sed -i '' -e "s/^version = \"$CURRENT_VERSION\"/version = \"$NEXT_VERSION\"/g" opensearch/Cargo.toml
           sed -i '' -e "s/^version = \"$CURRENT_VERSION\"/version = \"$NEXT_VERSION\"/g" api_generator/Cargo.toml
           sed -i '' -e "s/^version = \"$CURRENT_VERSION\"/version = \"$NEXT_VERSION\"/g" yaml_test_runner/Cargo.toml
@@ -38,8 +49,8 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ steps.github_app_token.outputs.token }}
-          base: main
-          branch: 'create-pull-request/patch-main'
+          base:  ${{ env.BASE }}
+          branch: 'create-pull-request/patch- ${{ env.BASE }}'
           commit-message: Increment version to ${{ env.NEXT_VERSION }}
           signoff: true
           delete-branch: true

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,50 @@
+name: Increment Version
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+permissions: {}
+jobs:
+  build:
+    if: github.repository == 'opensearch-project/opensearch-rs'
+    runs-on: ubuntu-latest
+    steps:
+      - name: GitHub App token
+        id: github_app_token
+        uses: tibdex/github-app-token@v2.1.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          installation_id: 22958780
+
+      - uses: actions/checkout@v4
+      - name: Fetch and Update Version Information
+        run: |
+          TAG=$(echo "${GITHUB_REF#refs/*/}")
+          CURRENT_VERSION_ARRAY=($(echo "$TAG" | tr . '\n'))
+          CURRENT_VERSION=$(IFS=. ; echo "${CURRENT_VERSION_ARRAY[*]:0:3}")
+          CURRENT_VERSION_ARRAY[2]=$((CURRENT_VERSION_ARRAY[2]+1))
+          NEXT_VERSION=$(IFS=. ; echo "${CURRENT_VERSION_ARRAY[*]:0:3}")
+          echo "TAG=$TAG" >> $GITHUB_ENV
+          echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
+          echo "NEXT_VERSION=$NEXT_VERSION" >> $GITHUB_ENV
+          sed -i '' -e "s/^version = \"$CURRENT_VERSION\"/version = \"$NEXT_VERSION\"/g" opensearch/Cargo.toml
+          sed -i '' -e "s/^version = \"$CURRENT_VERSION\"/version = \"$NEXT_VERSION\"/g" api_generator/Cargo.toml
+          sed -i '' -e "s/^version = \"$CURRENT_VERSION\"/version = \"$NEXT_VERSION\"/g" yaml_test_runner/Cargo.toml
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ steps.github_app_token.outputs.token }}
+          base: main
+          branch: 'create-pull-request/patch-main'
+          commit-message: Increment version to ${{ env.NEXT_VERSION }}
+          signoff: true
+          delete-branch: true
+          labels: |
+            autocut
+          title: '[AUTO] Increment version to ${{ env.NEXT_VERSION }}.'
+          body: |
+            I've noticed that a new tag ${{ env.TAG }} was pushed, and incremented the version from ${{ env.CURRENT_VERSION }} to ${{ env.NEXT_VERSION }}.


### PR DESCRIPTION
### Description
Add a `version` workflow that gets the current version from the released tag, and then updates modules with a patch bump

### Issues Resolved
https://github.com/opensearch-project/opensearch-rs/issues/69

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
