### PR TITLE
Add cluster version type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 
 ### Added
-
+- Added InfoResponse structure ([#187](https://github.com/opensearch-project/opensearch-rs/pull/187))
 ### Dependencies
 - Bumps `sysinfo` from 0.28.0 to 0.29.0
 - Bumps `serde_with` from ~2 to ~3

--- a/opensearch/src/lib.rs
+++ b/opensearch/src/lib.rs
@@ -388,6 +388,7 @@ mod readme {
 pub mod auth;
 pub mod cert;
 pub mod http;
+pub mod models;
 pub mod params;
 
 // GENERATED-BEGIN:namespace-modules

--- a/opensearch/src/models/mod.rs
+++ b/opensearch/src/models/mod.rs
@@ -1,0 +1,25 @@
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug)]
+#[doc = "Cluster information"]
+pub struct InfoResponse {
+    name: String,
+    cluster_name: String,
+    cluster_uuid: String,
+    version: OpenSearchVersionInfo,
+    #[serde(rename = "tagline")]
+    tag_line: String,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct OpenSearchVersionInfo {
+    distribution: String,
+    number: String,
+    build_type: String,
+    build_hash: String,
+    build_date: String,
+    build_snapshot: bool,
+    lucene_version: String,
+    minimum_wire_compatibility_version: String,
+    minimum_index_compatibility_version: String,
+}


### PR DESCRIPTION
### Description
Add a concrete type for the cluster version info, such that clients can parse the json like this:

```rust
client.info().send().await?.json::<ClusterInfo>().await?
```

## But according [to this](https://github.com/opensearch-project/opensearch-rs/blob/main/opensearch/src/root/mod.rs#L21), we shouldn't modify the file, so what will be the best way to go about it. Do we add this to the code generation ? . And if we do, do we create a module where we store the structure of possible typed responses, thereby setting a foundation for more type safety ?
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-rs/issues/94

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
