### PR TITLE
Correct the cargo make generate-certs target

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -19,7 +19,8 @@ OPENSEARCH_URL = { value = "${OPENSEARCH_PROTOCOL}://localhost:9200", condition 
 [tasks.generate-certs]
 category = "OpenSearch"
 description = "Generates SSL certificates used for integration tests"
-command = "bash ./.ci/generate-certs.sh"
+command = "bash"
+args =["./.ci/generate-certs.sh"]
 
 [tasks.run-opensearch]
 category = "OpenSearch"


### PR DESCRIPTION
### Description
Correct the cargo make generate-certs target

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
