### PR TITLE
set default download branch to main instead of master

### DIFF
--- a/api_generator/src/bin/run.rs
+++ b/api_generator/src/bin/run.rs
@@ -35,13 +35,14 @@ fn main() -> anyhow::Result<()> {
     let download_dir = fs::canonicalize(Path::new("./api_generator/rest_specs"))?;
     let generated_dir = fs::canonicalize(Path::new("./opensearch/src"))?;
     let last_downloaded_version = Path::new("./api_generator/rest_specs/last_downloaded_version");
+    let default_specification_download_branch = String::from("main");
 
     let mut download_specs = false;
     let mut answer = String::new();
     let default_branch = if last_downloaded_version.exists() {
         fs::read_to_string(last_downloaded_version)?
     } else {
-        String::from("master")
+        default_specification_download_branch
     };
     let mut branch = default_branch.clone();
 


### PR DESCRIPTION
### Description
Set the default branch for download of specifications to `main` instead of `master`

### Issues Resolved
https://github.com/opensearch-project/opensearch-rs/issues/190

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
