### PR TITLE
Update aws-sigv4 to `>= 0.57`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Added InfoResponse structure ([#187](https://github.com/opensearch-project/opensearch-rs/pull/187))
 - Added documentation on how to make raw json requests ([#196](https://github.com/opensearch-project/opensearch-rs/pull/196))
+
 ### Dependencies
 - Bumps `sysinfo` from 0.28.0 to 0.29.0
 - Bumps `serde_with` from ~2 to ~3
@@ -13,6 +14,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `syn` from 1.0 to 2.0
 - Bumps `toml` from 0.7.1 to 0.8.0
 - Bumps `dialoguer` from 0.10.2 to 0.11.0
+- Bumps `aws-*` from >=0.53 to >=0.57 ([#201](https://github.com/opensearch-project/opensearch-rs/pull/201))
 
 ### Changed
 - Moved @aditjind to Emeritus maintainers ([#170](https://github.com/opensearch-project/opensearch-rs/pull/170))

--- a/opensearch/Cargo.toml
+++ b/opensearch/Cargo.toml
@@ -26,7 +26,7 @@ native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
 
 # AWS SigV4 Auth support
-aws-auth = ["aws-credential-types", "aws-sigv4", "aws-types"]
+aws-auth = ["aws-credential-types", "aws-sigv4", "aws-smithy-runtime-api", "aws-types"]
 
 [dependencies]
 base64 = "0.21"
@@ -40,13 +40,15 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_with = "3"
 void = "1.0.2"
-aws-credential-types = { version = ">= 0.53", optional = true }
-aws-sigv4 = { version = ">= 0.53", optional = true }
-aws-types = { version = ">= 0.53", optional = true }
+aws-credential-types = { version = ">= 0.57", optional = true }
+aws-sigv4 = { version = ">= 0.57", optional = true }
+aws-smithy-runtime-api = { version = ">= 0.57", optional = true, features = ["client"]}
+aws-types = { version = ">= 0.57", optional = true }
 
 [dev-dependencies]
 anyhow = "1.0"
-aws-config = ">= 0.53"
+aws-config = ">= 0.57"
+aws-smithy-async = ">= 0.57"
 chrono = { version = "0.4", features = ["serde"] }
 clap = "2"
 futures = "0.3.1"
@@ -54,8 +56,11 @@ http = "0.2"
 hyper = { version = "0.14", default-features = false, features = ["tcp", "stream", "server"] }
 regex="1.4"
 sysinfo = "0.29.0"
+test-case = "3"
 textwrap = "0.16"
-tokio = { version = "1.0", default-features = false, features = ["macros", "net", "time", "rt-multi-thread"] }
+tokio = { version = "1.0", default-features = false, features = ["macros", "net", "time", "rt-multi-thread", "sync"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 xml-rs = "0.8"
 
 [build-dependencies]

--- a/opensearch/examples/advanced_index_actions.rs
+++ b/opensearch/examples/advanced_index_actions.rs
@@ -1,12 +1,24 @@
-use opensearch::auth::Credentials;
-use opensearch::indices::{
-    IndicesAddBlockParts, IndicesClearCacheParts, IndicesCloneParts, IndicesCloseParts,
-    IndicesCreateParts, IndicesDeleteParts, IndicesFlushParts, IndicesForcemergeParts,
-    IndicesOpenParts, IndicesPutSettingsParts, IndicesRefreshParts, IndicesSplitParts,
-};
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
 use opensearch::{
-    cert::CertificateValidation, http::transport::SingleNodeConnectionPool,
-    http::transport::TransportBuilder, OpenSearch,
+    auth::Credentials,
+    cert::CertificateValidation,
+    http::transport::{SingleNodeConnectionPool, TransportBuilder},
+    indices::{
+        IndicesAddBlockParts, IndicesClearCacheParts, IndicesCloneParts, IndicesCloseParts,
+        IndicesCreateParts, IndicesDeleteParts, IndicesFlushParts, IndicesForcemergeParts,
+        IndicesOpenParts, IndicesPutSettingsParts, IndicesRefreshParts, IndicesSplitParts,
+    },
+    OpenSearch,
 };
 use serde_json::json;
 use url::Url;

--- a/opensearch/examples/index_lifecycle.rs
+++ b/opensearch/examples/index_lifecycle.rs
@@ -1,13 +1,23 @@
-use opensearch::auth::Credentials;
-use opensearch::cert::CertificateValidation;
-use opensearch::http::transport::{SingleNodeConnectionPool, TransportBuilder};
-use opensearch::OpenSearch;
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
 use opensearch::{
+    auth::Credentials,
+    cert::CertificateValidation,
+    http::transport::{SingleNodeConnectionPool, TransportBuilder},
     indices::{
         IndicesCreateParts, IndicesDeleteParts, IndicesExistsParts, IndicesGetParts,
         IndicesPutMappingParts, IndicesPutSettingsParts,
     },
-    IndexParts,
+    IndexParts, OpenSearch,
 };
 use serde_json::json;
 use url::Url;

--- a/opensearch/examples/index_template.rs
+++ b/opensearch/examples/index_template.rs
@@ -1,12 +1,23 @@
-use opensearch::auth::Credentials;
-use opensearch::cluster::{ClusterDeleteComponentTemplateParts, ClusterPutComponentTemplateParts};
-use opensearch::indices::{
-    IndicesCreateParts, IndicesDeleteIndexTemplateParts, IndicesDeleteParts,
-    IndicesGetIndexTemplateParts, IndicesGetParts, IndicesPutIndexTemplateParts,
-};
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
 use opensearch::{
-    cert::CertificateValidation, http::transport::SingleNodeConnectionPool,
-    http::transport::TransportBuilder, OpenSearch,
+    auth::Credentials,
+    cert::CertificateValidation,
+    cluster::{ClusterDeleteComponentTemplateParts, ClusterPutComponentTemplateParts},
+    http::transport::{SingleNodeConnectionPool, TransportBuilder},
+    indices::{
+        IndicesCreateParts, IndicesDeleteIndexTemplateParts, IndicesDeleteParts,
+        IndicesGetIndexTemplateParts, IndicesGetParts, IndicesPutIndexTemplateParts,
+    },
+    OpenSearch,
 };
 use serde_json::json;
 use url::Url;

--- a/opensearch/examples/json.rs
+++ b/opensearch/examples/json.rs
@@ -1,12 +1,26 @@
-use serde_json::{json, Value};
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
 
-use opensearch::auth::Credentials;
-use opensearch::cert::CertificateValidation;
-use opensearch::http::headers::HeaderMap;
-use opensearch::http::transport::{SingleNodeConnectionPool, TransportBuilder};
-use opensearch::http::{Method, Url};
-use opensearch::http::request::JsonBody;
-use opensearch::OpenSearch;
+use opensearch::{
+    auth::Credentials,
+    cert::CertificateValidation,
+    http::{
+        headers::HeaderMap,
+        request::JsonBody,
+        transport::{SingleNodeConnectionPool, TransportBuilder},
+        Method, Url,
+    },
+    OpenSearch,
+};
+use serde_json::{json, Value};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -22,14 +36,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let document_id = "1";
 
     let info: Value = client
-        .send::<(), ()>(
-            Method::Get,
-            "/",
-            HeaderMap::new(),
-            None,
-            None,
-            None,
-        )
+        .send::<(), ()>(Method::Get, "/", HeaderMap::new(), None, None, None)
         .await?
         .json()
         .await?;
@@ -40,13 +47,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     // Create an index
-    let index_body : JsonBody<_> = json!({
+    let index_body: JsonBody<_> = json!({
         "settings": {
             "index": {
                 "number_of_shards" : 4
             }
         }
-    }).into();
+    })
+    .into();
 
     let create_index_response = client
         .send(
@@ -66,7 +74,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "title": "Moneyball",
         "director": "Bennett Miller",
         "year": "2011"
-    }).into();
+    })
+    .into();
     let create_document_response = client
         .send(
             Method::Put,
@@ -82,7 +91,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Search for a document
     let q = "miller";
-    let query : JsonBody<_> = json!({
+    let query: JsonBody<_> = json!({
         "size": 5,
         "query": {
             "multi_match": {
@@ -90,7 +99,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "fields": ["title^2", "director"]
             }
         }
-    }).into();
+    })
+    .into();
 
     let search_response = client
         .send(
@@ -105,11 +115,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     assert_eq!(search_response.status_code(), 200);
     let search_result = search_response.json::<Value>().await?;
-    println!("Hits: {:#?}", search_result["hits"]["hits"].as_array().unwrap());
+    println!(
+        "Hits: {:#?}",
+        search_result["hits"]["hits"].as_array().unwrap()
+    );
 
     // Delete the document
     let delete_document_response = client
-        .send::<(),()>(
+        .send::<(), ()>(
             Method::Delete,
             &format!("/{index_name}/_doc/{document_id}"),
             HeaderMap::new(),
@@ -123,7 +136,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Delete the index
     let delete_response = client
-        .send::<(),()>(
+        .send::<(), ()>(
             Method::Delete,
             &format!("/{index_name}"),
             HeaderMap::new(),

--- a/opensearch/src/lib.rs
+++ b/opensearch/src/lib.rs
@@ -27,7 +27,7 @@
 //! |-------------|---------------|
 //! | 1.x         | 1.x           |
 //! | 2.x         | 2.x, 1.x^     |
-//! - ^: With the exception of some previously deprecated APIs 
+//! - ^: With the exception of some previously deprecated APIs
 //!
 //! A major version of the client is compatible with the same major version of OpenSearch.
 //! Since OpenSearch is developed following [Semantic Versioning](https://semver.org/) principles,
@@ -44,7 +44,7 @@
 //! In the latter case, a 1.4.0 client won't contain API functions for APIs that are introduced in
 //! OpenSearch 1.5.0+, but for all other APIs available in OpenSearch, the respective API
 //! functions on the client will be compatible.
-//! 
+//!
 //! In some instances, a new major version of OpenSearch may remain compatible with an
 //! older major version of the client, which may not warrant a need to update the client.
 //! Please consult COMPATIBILITY.md for more details.

--- a/opensearch/tests/auth.rs
+++ b/opensearch/tests/auth.rs
@@ -45,8 +45,9 @@ async fn basic_auth_header() -> anyhow::Result<()> {
             write!(encoder, "username:password").unwrap();
         }
 
-        assert_eq!(
-            req.headers()["authorization"],
+        assert_header_eq!(
+            req,
+            "authorization",
             String::from_utf8(header_value).unwrap()
         );
         http::Response::default()
@@ -70,8 +71,9 @@ async fn api_key_header() -> anyhow::Result<()> {
             write!(encoder, "id:api_key").unwrap();
         }
 
-        assert_eq!(
-            req.headers()["authorization"],
+        assert_header_eq!(
+            req,
+            "authorization",
             String::from_utf8(header_value).unwrap()
         );
         http::Response::default()
@@ -89,7 +91,7 @@ async fn api_key_header() -> anyhow::Result<()> {
 #[tokio::test]
 async fn bearer_header() -> anyhow::Result<()> {
     let server = server::http(move |req| async move {
-        assert_eq!(req.headers()["authorization"], "Bearer access_token");
+        assert_header_eq!(req, "authorization", "Bearer access_token");
         http::Response::default()
     });
 

--- a/opensearch/tests/client.rs
+++ b/opensearch/tests/client.rs
@@ -52,9 +52,9 @@ use std::time::Duration;
 #[tokio::test]
 async fn default_user_agent_content_type_accept_headers() -> anyhow::Result<()> {
     let server = server::http(move |req| async move {
-        assert_eq!(req.headers()["user-agent"], DEFAULT_USER_AGENT);
-        assert_eq!(req.headers()["content-type"], "application/json");
-        assert_eq!(req.headers()["accept"], "application/json");
+        assert_header_eq!(req, "user-agent", DEFAULT_USER_AGENT);
+        assert_header_eq!(req, "content-type", "application/json");
+        assert_header_eq!(req, "accept", "application/json");
         http::Response::default()
     });
 
@@ -67,7 +67,7 @@ async fn default_user_agent_content_type_accept_headers() -> anyhow::Result<()> 
 #[tokio::test]
 async fn default_header() -> anyhow::Result<()> {
     let server = server::http(move |req| async move {
-        assert_eq!(req.headers()["x-opaque-id"], "foo");
+        assert_header_eq!(req, "x-opaque-id", "foo");
         http::Response::default()
     });
 
@@ -85,7 +85,7 @@ async fn default_header() -> anyhow::Result<()> {
 #[tokio::test]
 async fn override_default_header() -> anyhow::Result<()> {
     let server = server::http(move |req| async move {
-        assert_eq!(req.headers()["x-opaque-id"], "bar");
+        assert_header_eq!(req, "x-opaque-id", "bar");
         http::Response::default()
     });
 
@@ -110,7 +110,7 @@ async fn override_default_header() -> anyhow::Result<()> {
 #[tokio::test]
 async fn x_opaque_id_header() -> anyhow::Result<()> {
     let server = server::http(move |req| async move {
-        assert_eq!(req.headers()["x-opaque-id"], "foo");
+        assert_header_eq!(req, "x-opaque-id", "foo");
         http::Response::default()
     });
 

--- a/opensearch/tests/common/mod.rs
+++ b/opensearch/tests/common/mod.rs
@@ -28,8 +28,23 @@
  * GitHub history for details.
  */
 
-pub mod client;
-pub mod server;
+#![allow(unused)]
 
-#[allow(unused)]
-pub static DEFAULT_USER_AGENT: &str = concat!("opensearch-rs/", env!("CARGO_PKG_VERSION"));
+pub(crate) mod client;
+pub(crate) mod server;
+
+pub(crate) static DEFAULT_USER_AGENT: &str = concat!("opensearch-rs/", env!("CARGO_PKG_VERSION"));
+
+macro_rules! assert_header_eq {
+    ($req:expr, $header:expr, $value:expr) => {
+        assert_eq!($req.headers()[$header], $value);
+    };
+}
+
+static TRACING: std::sync::Once = std::sync::Once::new();
+
+pub(crate) fn tracing_init() {
+    TRACING.call_once(|| tracing_subscriber::fmt::init())
+}
+
+pub(crate) use assert_header_eq;


### PR DESCRIPTION
### Description
Update aws-sigv4 to `>= 0.57`

- Expose signing time source as configurable for testability.
- Explicitly add global default headers upfront rather than via reqwest::Client so that they are taken into account for signing.
- Add test cases for sigv4 based off those in opensearch-net.

### Issues Resolved
Fixes #200 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
