### PR TITLE
Fix `sed` invocation in version bump workflow

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -41,9 +41,9 @@ jobs:
       - name: Increment Patch Version
         run: |
           echo Incrementing $CURRENT_VERSION to $NEXT_VERSION
-          sed -i '' -e "s/^version = \"$CURRENT_VERSION\"/version = \"$NEXT_VERSION\"/g" opensearch/Cargo.toml
-          sed -i '' -e "s/^version = \"$CURRENT_VERSION\"/version = \"$NEXT_VERSION\"/g" api_generator/Cargo.toml
-          sed -i '' -e "s/^version = \"$CURRENT_VERSION\"/version = \"$NEXT_VERSION\"/g" yaml_test_runner/Cargo.toml
+          sed -i'' -e "s/^version = \"$CURRENT_VERSION\"/version = \"$NEXT_VERSION\"/g" opensearch/Cargo.toml
+          sed -i'' -e "s/^version = \"$CURRENT_VERSION\"/version = \"$NEXT_VERSION\"/g" api_generator/Cargo.toml
+          sed -i'' -e "s/^version = \"$CURRENT_VERSION\"/version = \"$NEXT_VERSION\"/g" yaml_test_runner/Cargo.toml
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
### Description
Fix `sed` invocation in version bump workflow

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
