### PR TITLE
Bump version in `main` to next-in-dev version `3.0.0`

### DIFF
--- a/api_generator/Cargo.toml
+++ b/api_generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api_generator"
-version = "2.2.0"
+version = "3.0.0"
 publish = false
 description = "Generates source code for opensearch package, from the OpenSearch REST API specs"
 repository = "https://github.com/opensearch-project/opensearch-rs"

--- a/opensearch/Cargo.toml
+++ b/opensearch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opensearch"
-version = "2.2.0"
+version = "3.0.0"
 edition = "2018"
 authors = ["Elastic and Contributors", "OpenSearch Contributors"]
 description = "Official OpenSearch Rust client"

--- a/yaml_test_runner/Cargo.toml
+++ b/yaml_test_runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yaml_test_runner"
-version = "2.2.0"
+version = "3.0.0"
 publish = false
 edition = "2018"
 authors = ["Elastic and Contributors", "OpenSearch Contributors"]


### PR DESCRIPTION
### Description
Bump version in `main` to next-in-dev version `3.0.0`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
