### PR TITLE
Stabilize `aws-*` dependencies at `1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 ### Dependencies
-- Bound `aws-*` dependencies to `<1.0` ([#215](https://github.com/opensearch-project/opensearch-rs/pull/215))
+- Bumps `aws-*` dependencies to `1` ([#219](https://github.com/opensearch-project/opensearch-rs/pull/219))
 - Bumps `itertools` from 0.11.0 to 0.12.0
 
 ### Changed

--- a/opensearch/Cargo.toml
+++ b/opensearch/Cargo.toml
@@ -40,15 +40,15 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_with = "3"
 void = "1.0.2"
-aws-credential-types = { version = ">= 0.57, <1.0", optional = true }
-aws-sigv4 = { version = ">= 0.57, <1.0", optional = true }
-aws-smithy-runtime-api = { version = ">= 0.57, <1.0", optional = true, features = ["client"]}
-aws-types = { version = ">= 0.57, <1.0", optional = true }
+aws-credential-types = { version = "1", optional = true }
+aws-sigv4 = { version = "1", optional = true }
+aws-smithy-runtime-api = { version = "1", optional = true, features = ["client"]}
+aws-types = { version = "1", optional = true }
 
 [dev-dependencies]
 anyhow = "1.0"
-aws-config = ">= 0.57, <1.0"
-aws-smithy-async = ">= 0.57, <1.0"
+aws-config = "1"
+aws-smithy-async = "1"
 chrono = { version = "0.4", features = ["serde"] }
 clap = "2"
 futures = "0.3.1"


### PR DESCRIPTION
### Description
My previous PR #215 had jumped the gun, and had actually just caught `aws-sdk-rust` mid-release. All the `aws-*` crates we depend on have now been stabilized at `1.0.0` 🎉 🥳 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
