### PR TITLE
Upgrade `hyper` from `0.14` to `1` in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Dependencies
 - Bumps `aws-*` dependencies to `1` ([#219](https://github.com/opensearch-project/opensearch-rs/pull/219))
 - Bumps `itertools` from 0.11.0 to 0.12.0
+- Bumps `hyper` from 0.14 to 1 in tests ([#221](https://github.com/opensearch-project/opensearch-rs/pull/221))
 
 ### Changed
 

--- a/opensearch/Cargo.toml
+++ b/opensearch/Cargo.toml
@@ -52,13 +52,14 @@ aws-smithy-async = "1"
 chrono = { version = "0.4", features = ["serde"] }
 clap = "2"
 futures = "0.3.1"
-http = "0.2"
-hyper = { version = "0.14", default-features = false, features = ["tcp", "stream", "server"] }
+http-body-util = "0.1.0"
+hyper = { version = "1", features = ["full"] }
+hyper-util = { version = "0.1", features = ["full"] }
 regex="1.4"
 sysinfo = "0.29.0"
 test-case = "3"
 textwrap = "0.16"
-tokio = { version = "1.0", default-features = false, features = ["macros", "net", "time", "rt-multi-thread", "sync"] }
+tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 xml-rs = "0.8"

--- a/opensearch/tests/auth.rs
+++ b/opensearch/tests/auth.rs
@@ -50,7 +50,7 @@ async fn basic_auth_header() -> anyhow::Result<()> {
             "authorization",
             String::from_utf8(header_value).unwrap()
         );
-        http::Response::default()
+        server::empty_response()
     });
 
     let builder = client::create_builder(format!("http://{}", server.addr()).as_ref())
@@ -76,7 +76,7 @@ async fn api_key_header() -> anyhow::Result<()> {
             "authorization",
             String::from_utf8(header_value).unwrap()
         );
-        http::Response::default()
+        server::empty_response()
     });
 
     let builder = client::create_builder(format!("http://{}", server.addr()).as_ref())
@@ -92,7 +92,7 @@ async fn api_key_header() -> anyhow::Result<()> {
 async fn bearer_header() -> anyhow::Result<()> {
     let server = server::http(move |req| async move {
         assert_header_eq!(req, "authorization", "Bearer access_token");
-        http::Response::default()
+        server::empty_response()
     });
 
     let builder = client::create_builder(format!("http://{}", server.addr()).as_ref())

--- a/opensearch/tests/aws_auth.rs
+++ b/opensearch/tests/aws_auth.rs
@@ -18,9 +18,9 @@ use aws_credential_types::Credentials as AwsCredentials;
 use aws_smithy_async::time::StaticTimeSource;
 use aws_types::region::Region;
 use common::*;
-use http::header::HOST;
 use opensearch::{auth::Credentials, indices::IndicesCreateParts, OpenSearch};
 use regex::Regex;
+use reqwest::header::HOST;
 use serde_json::json;
 use std::convert::TryInto;
 use test_case::test_case;
@@ -105,7 +105,7 @@ async fn aws_auth_get() -> anyhow::Result<()> {
             "x-amz-content-sha256",
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         ); // SHA of empty string
-        http::Response::default()
+        server::empty_response()
     });
 
     let client = create_aws_client(format!("http://{}", server.addr()).as_ref())?;
@@ -122,7 +122,7 @@ async fn aws_auth_post() -> anyhow::Result<()> {
             "x-amz-content-sha256",
             "f3a842f988a653a734ebe4e57c45f19293a002241a72f0b3abbff71e4f5297b9"
         ); // SHA of the JSON
-        http::Response::default()
+        server::empty_response()
     });
 
     let client = create_aws_client(format!("http://{}", server.addr()).as_ref())?;

--- a/opensearch/tests/client.rs
+++ b/opensearch/tests/client.rs
@@ -55,7 +55,7 @@ async fn default_user_agent_content_type_accept_headers() -> anyhow::Result<()> 
         assert_header_eq!(req, "user-agent", DEFAULT_USER_AGENT);
         assert_header_eq!(req, "content-type", "application/json");
         assert_header_eq!(req, "accept", "application/json");
-        http::Response::default()
+        server::empty_response()
     });
 
     let client = client::create_for_url(format!("http://{}", server.addr()).as_ref());
@@ -68,7 +68,7 @@ async fn default_user_agent_content_type_accept_headers() -> anyhow::Result<()> 
 async fn default_header() -> anyhow::Result<()> {
     let server = server::http(move |req| async move {
         assert_header_eq!(req, "x-opaque-id", "foo");
-        http::Response::default()
+        server::empty_response()
     });
 
     let builder = client::create_builder(format!("http://{}", server.addr()).as_ref()).header(
@@ -86,7 +86,7 @@ async fn default_header() -> anyhow::Result<()> {
 async fn override_default_header() -> anyhow::Result<()> {
     let server = server::http(move |req| async move {
         assert_header_eq!(req, "x-opaque-id", "bar");
-        http::Response::default()
+        server::empty_response()
     });
 
     let builder = client::create_builder(format!("http://{}", server.addr()).as_ref()).header(
@@ -111,7 +111,7 @@ async fn override_default_header() -> anyhow::Result<()> {
 async fn x_opaque_id_header() -> anyhow::Result<()> {
     let server = server::http(move |req| async move {
         assert_header_eq!(req, "x-opaque-id", "foo");
-        http::Response::default()
+        server::empty_response()
     });
 
     let client = client::create_for_url(format!("http://{}", server.addr()).as_ref());
@@ -131,7 +131,7 @@ async fn x_opaque_id_header() -> anyhow::Result<()> {
 async fn uses_global_request_timeout() {
     let server = server::http(move |_| async move {
         std::thread::sleep(Duration::from_secs(1));
-        http::Response::default()
+        server::empty_response()
     });
 
     let builder = client::create_builder(format!("http://{}", server.addr()).as_ref())
@@ -150,7 +150,7 @@ async fn uses_global_request_timeout() {
 async fn uses_call_request_timeout() {
     let server = server::http(move |_| async move {
         std::thread::sleep(Duration::from_secs(1));
-        http::Response::default()
+        server::empty_response()
     });
 
     let builder = client::create_builder(format!("http://{}", server.addr()).as_ref())
@@ -173,7 +173,7 @@ async fn uses_call_request_timeout() {
 async fn call_request_timeout_supersedes_global_timeout() {
     let server = server::http(move |_| async move {
         std::thread::sleep(Duration::from_secs(1));
-        http::Response::default()
+        server::empty_response()
     });
 
     let builder = client::create_builder(format!("http://{}", server.addr()).as_ref())
@@ -246,7 +246,7 @@ async fn serialize_querystring() -> anyhow::Result<()> {
                 req.uri().query(),
                 Some("filter_path=took%2C_shards&pretty=true&q=title%3AOpenSearch&track_total_hits=100000")
             );
-        http::Response::default()
+        server::empty_response()
     });
 
     let client = client::create_for_url(format!("http://{}", server.addr()).as_ref());


### PR DESCRIPTION
### Description
Upgrades `hyper` from `0.14` to `1` in tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
