### PR TITLE
[Backport 2.1] Bound `aws-*` to code-compatible versions `>=0.53,<0.57`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Security
 
+## [2.1.1]
+
+### Dependencies
+- Bound `aws-*` to code-compatible versions `>=0.53,<0.57` ([#225](https://github.com/opensearch-project/opensearch-rs/pull/225))
+
 ## [2.1.0]
 
 ### Added

--- a/api_generator/Cargo.toml
+++ b/api_generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api_generator"
-version = "2.1.0"
+version = "2.1.1"
 publish = false
 description = "Generates source code for opensearch package, from the OpenSearch REST API specs"
 repository = "https://github.com/opensearch-project/opensearch-rs"

--- a/opensearch/Cargo.toml
+++ b/opensearch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opensearch"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2018"
 authors = ["Elastic and Contributors", "OpenSearch Contributors"]
 description = "Official OpenSearch Rust client"
@@ -40,13 +40,13 @@ serde = { version = "~1", features = ["derive"] }
 serde_json = "~1"
 serde_with = "~2"
 void = "1.0.2"
-aws-credential-types = { version = ">= 0.53", optional = true }
-aws-sigv4 = { version = ">= 0.53", optional = true }
-aws-types = { version = ">= 0.53", optional = true }
+aws-credential-types = { version = ">= 0.53, < 0.57", optional = true }
+aws-sigv4 = { version = ">= 0.53, < 0.57", optional = true }
+aws-types = { version = ">= 0.53, < 0.57", optional = true }
 
 [dev-dependencies]
 anyhow = "1.0"
-aws-config = ">= 0.53"
+aws-config = ">= 0.53, < 0.57"
 chrono = { version = "^0.4", features = ["serde"] }
 clap = "~2"
 futures = "0.3.1"

--- a/yaml_test_runner/Cargo.toml
+++ b/yaml_test_runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yaml_test_runner"
-version = "2.1.0"
+version = "2.1.1"
 publish = false
 edition = "2018"
 authors = ["Elastic and Contributors", "OpenSearch Contributors"]


### PR DESCRIPTION
### Description
Bounds `aws-*` to code-compatible versions `>=0.53,<0.57`

### Issues Resolved
Fixes #223 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
