### PR TITLE
Refactor mock HTTP server tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
           version: 2.8.0
           secured: true
 
-      - name: Run Tests (${{ matrix.test-args }})
+      - name: Run Tests
         working-directory: client
         run: cargo make test ${{ matrix.test-args }}
         env:

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -20,18 +20,14 @@ OPENSEARCH_URL = { value = "${OPENSEARCH_PROTOCOL}://localhost:9200", condition 
 category = "OpenSearch"
 description = "Generates SSL certificates used for integration tests"
 command = "bash"
-args =["./.ci/generate-certs.sh"]
+args = ["./.ci/generate-certs.sh"]
 
 [tasks.run-opensearch]
 category = "OpenSearch"
 private = true
 condition = { env_set = [ "STACK_VERSION"], env_false = ["CARGO_MAKE_CI"] }
-
-[tasks.run-opensearch.linux]
-command = "./.ci/run-opensearch.sh"
-
-[tasks.run-opensearch.mac]
-command = "./.ci/run-opensearch.sh"
+command = "bash"
+args = ["./.ci/run-opensearch.sh"]
 
 [tasks.run-opensearch.windows]
 script_runner = "cmd"

--- a/api_generator/src/rest_spec/mod.rs
+++ b/api_generator/src/rest_spec/mod.rs
@@ -41,7 +41,7 @@ pub fn download_specs(branch: &str, download_dir: &Path) -> anyhow::Result<()> {
         .build()
         .unwrap();
 
-    let response = client.get(&url).send()?;
+    let response = client.get(url).send()?;
     let tar = GzDecoder::new(response);
     let mut archive = Archive::new(tar);
 

--- a/opensearch/Cargo.toml
+++ b/opensearch/Cargo.toml
@@ -55,7 +55,6 @@ futures = "0.3.1"
 http-body-util = "0.1.0"
 hyper = { version = "1", features = ["full"] }
 hyper-util = { version = "0.1", features = ["full"] }
-regex="1.4"
 sysinfo = "0.29.0"
 test-case = "3"
 textwrap = "0.16"

--- a/opensearch/src/auth.rs
+++ b/opensearch/src/auth.rs
@@ -90,7 +90,7 @@ impl From<ClientCertificate> for Credentials {
     }
 }
 
-#[cfg(any(feature = "aws-auth"))]
+#[cfg(feature = "aws-auth")]
 impl std::convert::TryFrom<&aws_types::SdkConfig> for Credentials {
     type Error = super::Error;
 
@@ -107,7 +107,7 @@ impl std::convert::TryFrom<&aws_types::SdkConfig> for Credentials {
     }
 }
 
-#[cfg(any(feature = "aws-auth"))]
+#[cfg(feature = "aws-auth")]
 impl std::convert::TryFrom<aws_types::SdkConfig> for Credentials {
     type Error = super::Error;
 

--- a/opensearch/src/models/mod.rs
+++ b/opensearch/src/models/mod.rs
@@ -1,3 +1,16 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+#![allow(unused)]
+
 use serde::Deserialize;
 
 #[derive(Deserialize, Debug)]

--- a/opensearch/tests/aws_auth.rs
+++ b/opensearch/tests/aws_auth.rs
@@ -12,18 +12,33 @@
 #![cfg(feature = "aws-auth")]
 
 pub mod common;
-use aws_config::SdkConfig;
-use aws_credential_types::provider::SharedCredentialsProvider;
-use aws_credential_types::Credentials as AwsCredentials;
+use aws_credential_types::{provider::SharedCredentialsProvider, Credentials as AwsCredentials};
 use aws_smithy_async::time::StaticTimeSource;
 use aws_types::region::Region;
-use common::*;
-use opensearch::{auth::Credentials, indices::IndicesCreateParts, OpenSearch};
-use regex::Regex;
-use reqwest::header::HOST;
+use common::{server::MockServer, tracing_init};
+use opensearch::{
+    http::{headers::HOST, transport::TransportBuilder},
+    indices::IndicesCreateParts,
+};
+use reqwest::header::HeaderValue;
 use serde_json::json;
-use std::convert::TryInto;
 use test_case::test_case;
+
+fn sigv4_config(transport: TransportBuilder, service_name: &str) -> TransportBuilder {
+    let aws_creds = AwsCredentials::new("test-access-key", "test-secret-key", None, None, "test");
+    let region = Region::new("ap-southeast-2");
+    let time_source = StaticTimeSource::from_secs(1673626117); // 2023-01-13 16:08:37 +0000
+
+    transport
+        .auth(opensearch::auth::Credentials::AwsSigV4(
+            SharedCredentialsProvider::new(aws_creds),
+            region,
+        ))
+        .service_name(service_name)
+        .sigv4_time_source(time_source.into())
+}
+
+const LOCALHOST: HeaderValue = HeaderValue::from_static("localhost");
 
 #[test_case("es", "10c9be415f4b9f15b12abbb16bd3e3730b2e6c76e0cf40db75d08a44ed04a3a1"; "when service name is es")]
 #[test_case("aoss", "34903aef90423aa7dd60575d3d45316c6ef2d57bbe564a152b41bf8f5917abf6"; "when service name is aoss")]
@@ -35,22 +50,12 @@ async fn aws_auth_signs_correctly(
 ) -> anyhow::Result<()> {
     tracing_init();
 
-    let (server, mut rx) = server::capturing_http();
+    let mut server = MockServer::start()?;
 
-    let aws_creds = AwsCredentials::new("test-access-key", "test-secret-key", None, None, "test");
-    let region = Region::new("ap-southeast-2");
-    let time_source = StaticTimeSource::from_secs(1673626117); // 2023-01-13 16:08:37 +0000
     let host = format!("aaabbbcccddd111222333.ap-southeast-2.{service_name}.amazonaws.com");
 
-    let transport_builder = client::create_builder(&format!("http://{}", server.addr()))
-        .auth(Credentials::AwsSigV4(
-            SharedCredentialsProvider::new(aws_creds),
-            region,
-        ))
-        .service_name(service_name)
-        .sigv4_time_source(time_source.into())
-        .header(HOST, host.parse().unwrap());
-    let client = client::create(transport_builder);
+    let client =
+        server.client_with(|b| sigv4_config(b, service_name).header(HOST, host.parse().unwrap()));
 
     let _ = client
         .indices()
@@ -74,59 +79,51 @@ async fn aws_auth_signs_correctly(
         .send()
         .await?;
 
-    let sent_req = rx.recv().await.expect("should have sent a request");
+    let sent_req = server.received_request().await?;
 
-    assert_header_eq!(sent_req, "accept", "application/json");
-    assert_header_eq!(sent_req, "content-type", "application/json");
-    assert_header_eq!(sent_req, "host", host);
-    assert_header_eq!(sent_req, "x-amz-date", "20230113T160837Z");
-    assert_header_eq!(
-        sent_req,
-        "x-amz-content-sha256",
-        "4c770eaed349122a28302ff73d34437cad600acda5a9dd373efc7da2910f8564"
+    assert_eq!(sent_req.header("accept"), Some("application/json"));
+    assert_eq!(sent_req.header("content-type"), Some("application/json"));
+    assert_eq!(sent_req.header("host"), Some(host.as_str()));
+    assert_eq!(sent_req.header("x-amz-date"), Some("20230113T160837Z"));
+    assert_eq!(
+        sent_req.header("x-amz-content-sha256"),
+        Some("4c770eaed349122a28302ff73d34437cad600acda5a9dd373efc7da2910f8564")
     );
-    assert_header_eq!(sent_req, "authorization", format!("AWS4-HMAC-SHA256 Credential=test-access-key/20230113/ap-southeast-2/{service_name}/aws4_request, SignedHeaders=accept;content-type;host;x-amz-content-sha256;x-amz-date, Signature={expected_signature}"));
+    assert_eq!(sent_req.header("authorization"), Some(format!("AWS4-HMAC-SHA256 Credential=test-access-key/20230113/ap-southeast-2/{service_name}/aws4_request, SignedHeaders=accept;content-type;host;x-amz-content-sha256;x-amz-date, Signature={expected_signature}").as_str()));
 
     Ok(())
 }
 
 #[tokio::test]
 async fn aws_auth_get() -> anyhow::Result<()> {
-    let server = server::http(move |req| async move {
-        let authorization_header = req.headers()["authorization"].to_str().unwrap();
-        let re = Regex::new(r"^AWS4-HMAC-SHA256 Credential=id/\d*/us-west-1/custom/aws4_request, SignedHeaders=accept;content-type;host;x-amz-content-sha256;x-amz-date, Signature=[a-f,0-9].*$").unwrap();
-        assert!(
-            re.is_match(authorization_header),
-            "{}",
-            authorization_header
-        );
-        assert_header_eq!(
-            req,
-            "x-amz-content-sha256",
-            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-        ); // SHA of empty string
-        server::empty_response()
-    });
+    tracing_init();
 
-    let client = create_aws_client(format!("http://{}", server.addr()).as_ref())?;
-    let _response = client.ping().send().await?;
+    let mut server = MockServer::start()?;
+
+    let client = server.client_with(|b| sigv4_config(b, "custom").header(HOST, LOCALHOST));
+
+    let _ = client.ping().send().await?;
+
+    let sent_req = server.received_request().await?;
+
+    assert_eq!(sent_req.header("authorization"), Some("AWS4-HMAC-SHA256 Credential=test-access-key/20230113/ap-southeast-2/custom/aws4_request, SignedHeaders=accept;content-type;host;x-amz-content-sha256;x-amz-date, Signature=e5aa6e5d9e1b86b86ed31fbb10dd62b4e93423b77830f8189701421d3e9f65bd"));
+    assert_eq!(
+        sent_req.header("x-amz-content-sha256"),
+        Some("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+    ); // SHA of zero-length body
 
     Ok(())
 }
 
 #[tokio::test]
 async fn aws_auth_post() -> anyhow::Result<()> {
-    let server = server::http(move |req| async move {
-        assert_header_eq!(
-            req,
-            "x-amz-content-sha256",
-            "f3a842f988a653a734ebe4e57c45f19293a002241a72f0b3abbff71e4f5297b9"
-        ); // SHA of the JSON
-        server::empty_response()
-    });
+    tracing_init();
 
-    let client = create_aws_client(format!("http://{}", server.addr()).as_ref())?;
-    client
+    let mut server = MockServer::start()?;
+
+    let client = server.client_with(|b| sigv4_config(b, "custom").header(HOST, LOCALHOST));
+
+    let _ = client
         .index(opensearch::IndexParts::Index("movies"))
         .body(serde_json::json!({
                 "title": "Moneyball",
@@ -137,18 +134,12 @@ async fn aws_auth_post() -> anyhow::Result<()> {
         .send()
         .await?;
 
-    Ok(())
-}
+    let sent_req = server.received_request().await?;
 
-fn create_aws_client(addr: &str) -> anyhow::Result<OpenSearch> {
-    let aws_creds = AwsCredentials::new("id", "secret", None, None, "token");
-    let creds_provider = SharedCredentialsProvider::new(aws_creds);
-    let aws_config = SdkConfig::builder()
-        .credentials_provider(creds_provider)
-        .region(Region::new("us-west-1"))
-        .build();
-    let builder = client::create_builder(addr)
-        .auth(aws_config.clone().try_into()?)
-        .service_name("custom");
-    Ok(client::create(builder))
+    assert_eq!(
+        sent_req.header("x-amz-content-sha256"),
+        Some("f3a842f988a653a734ebe4e57c45f19293a002241a72f0b3abbff71e4f5297b9")
+    ); // SHA of the JSON
+
+    Ok(())
 }

--- a/opensearch/tests/cert.rs
+++ b/opensearch/tests/cert.rs
@@ -50,8 +50,7 @@ fn expected_error_message() -> &'static str {
 #[tokio::test]
 #[cfg(feature = "native-tls")]
 async fn default_certificate_validation() -> anyhow::Result<()> {
-    let builder = client::create_default_builder().cert_validation(CertificateValidation::Default);
-    let client = client::create(builder);
+    let client = client::create_with(|b| b.cert_validation(CertificateValidation::Default));
 
     match client.ping().send().await {
         Ok(response) => Err(anyhow!(
@@ -77,8 +76,7 @@ async fn default_certificate_validation() -> anyhow::Result<()> {
 #[tokio::test]
 #[cfg(all(feature = "rustls-tls", not(feature = "native-tls")))]
 async fn default_certificate_validation_rustls_tls() -> anyhow::Result<()> {
-    let builder = client::create_default_builder().cert_validation(CertificateValidation::Default);
-    let client = client::create(builder);
+    let client = client::create_with(|b| b.cert_validation(CertificateValidation::Default));
 
     match client.ping().send().await {
         Ok(response) => Err(anyhow!(
@@ -103,8 +101,7 @@ async fn default_certificate_validation_rustls_tls() -> anyhow::Result<()> {
 /// Allows any certificate through
 #[tokio::test]
 async fn none_certificate_validation() -> anyhow::Result<()> {
-    let builder = client::create_default_builder().cert_validation(CertificateValidation::None);
-    let client = client::create(builder);
+    let client = client::create_with(|b| b.cert_validation(CertificateValidation::None));
     let _response = client.ping().send().await?;
     Ok(())
 }
@@ -118,9 +115,7 @@ async fn none_certificate_validation() -> anyhow::Result<()> {
 ))]
 async fn full_certificate_ca_validation() -> anyhow::Result<()> {
     let cert = Certificate::from_pem(CA_CERT)?;
-    let builder =
-        client::create_default_builder().cert_validation(CertificateValidation::Full(cert));
-    let client = client::create(builder);
+    let client = client::create_with(|b| b.cert_validation(CertificateValidation::Full(cert)));
     let _response = client.ping().send().await?;
     Ok(())
 }
@@ -135,9 +130,7 @@ async fn full_certificate_ca_chain_validation() -> anyhow::Result<()> {
     let mut cert = Certificate::from_pem(CA_CHAIN_CERT)?;
     cert.append(Certificate::from_pem(CA_CERT)?);
     assert_eq!(cert.len(), 3, "expected three certificates in CA chain");
-    let builder =
-        client::create_default_builder().cert_validation(CertificateValidation::Full(cert));
-    let client = client::create(builder);
+    let client = client::create_with(|b| b.cert_validation(CertificateValidation::Full(cert)));
     let _response = client.ping().send().await?;
     Ok(())
 }
@@ -147,9 +140,7 @@ async fn full_certificate_ca_chain_validation() -> anyhow::Result<()> {
 #[cfg(all(windows, feature = "native-tls"))]
 async fn full_certificate_validation() -> anyhow::Result<()> {
     let cert = Certificate::from_pem(ESNODE_CERT)?;
-    let builder =
-        client::create_default_builder().cert_validation(CertificateValidation::Full(cert));
-    let client = client::create(builder);
+    let client = client::create_with(|b| b.cert_validation(CertificateValidation::Full(cert)));
     let _response = client.ping().send().await?;
     Ok(())
 }
@@ -163,9 +154,7 @@ async fn full_certificate_validation_rustls_tls() -> anyhow::Result<()> {
     chain.extend(ESNODE_CERT);
 
     let cert = Certificate::from_pem(chain.as_slice())?;
-    let builder =
-        client::create_default_builder().cert_validation(CertificateValidation::Full(cert));
-    let client = client::create(builder);
+    let client = client::create_with(|b| b.cert_validation(CertificateValidation::Full(cert)));
     let _response = client.ping().send().await?;
     Ok(())
 }
@@ -176,9 +165,7 @@ async fn full_certificate_validation_rustls_tls() -> anyhow::Result<()> {
 #[cfg(all(unix, feature = "native-tls"))]
 async fn full_certificate_validation() -> anyhow::Result<()> {
     let cert = Certificate::from_pem(ESNODE_CERT)?;
-    let builder =
-        client::create_default_builder().cert_validation(CertificateValidation::Full(cert));
-    let client = client::create(builder);
+    let client = client::create_with(|b| b.cert_validation(CertificateValidation::Full(cert)));
 
     match client.ping().send().await {
         Ok(response) => Err(anyhow!(
@@ -205,9 +192,8 @@ async fn full_certificate_validation() -> anyhow::Result<()> {
 #[cfg(all(windows, feature = "native-tls"))]
 async fn certificate_certificate_validation() -> anyhow::Result<()> {
     let cert = Certificate::from_pem(ESNODE_CERT)?;
-    let builder =
-        client::create_default_builder().cert_validation(CertificateValidation::Certificate(cert));
-    let client = client::create(builder);
+    let client =
+        client::create_with(|b| b.cert_validation(CertificateValidation::Certificate(cert)));
     let _response = client.ping().send().await?;
     Ok(())
 }
@@ -218,9 +204,8 @@ async fn certificate_certificate_validation() -> anyhow::Result<()> {
 #[cfg(all(unix, feature = "native-tls"))]
 async fn certificate_certificate_validation() -> anyhow::Result<()> {
     let cert = Certificate::from_pem(ESNODE_CERT)?;
-    let builder =
-        client::create_default_builder().cert_validation(CertificateValidation::Certificate(cert));
-    let client = client::create(builder);
+    let client =
+        client::create_with(|b| b.cert_validation(CertificateValidation::Certificate(cert)));
 
     match client.ping().send().await {
         Ok(response) => Err(anyhow!(
@@ -248,9 +233,8 @@ async fn certificate_certificate_validation() -> anyhow::Result<()> {
 #[cfg(all(feature = "native-tls", not(target_os = "macos")))]
 async fn certificate_certificate_ca_validation() -> anyhow::Result<()> {
     let cert = Certificate::from_pem(CA_CERT)?;
-    let builder =
-        client::create_default_builder().cert_validation(CertificateValidation::Certificate(cert));
-    let client = client::create(builder);
+    let client =
+        client::create_with(|b| b.cert_validation(CertificateValidation::Certificate(cert)));
     let _response = client.ping().send().await?;
     Ok(())
 }
@@ -260,9 +244,8 @@ async fn certificate_certificate_ca_validation() -> anyhow::Result<()> {
 #[cfg(feature = "native-tls")]
 async fn fail_certificate_certificate_validation() -> anyhow::Result<()> {
     let cert = Certificate::from_pem(ESNODE_NO_SAN_CERT)?;
-    let builder =
-        client::create_default_builder().cert_validation(CertificateValidation::Certificate(cert));
-    let client = client::create(builder);
+    let client =
+        client::create_with(|b| b.cert_validation(CertificateValidation::Certificate(cert)));
 
     match client.ping().send().await {
         Ok(response) => Err(anyhow!(

--- a/opensearch/tests/common/mod.rs
+++ b/opensearch/tests/common/mod.rs
@@ -28,23 +28,13 @@
  * GitHub history for details.
  */
 
-#![allow(unused)]
+pub mod client;
+pub mod server;
 
-pub(crate) mod client;
-pub(crate) mod server;
-
-pub(crate) static DEFAULT_USER_AGENT: &str = concat!("opensearch-rs/", env!("CARGO_PKG_VERSION"));
-
-macro_rules! assert_header_eq {
-    ($req:expr, $header:expr, $value:expr) => {
-        assert_eq!($req.headers()[$header], $value);
-    };
-}
+pub static DEFAULT_USER_AGENT: &str = concat!("opensearch-rs/", env!("CARGO_PKG_VERSION"));
 
 static TRACING: std::sync::Once = std::sync::Once::new();
 
-pub(crate) fn tracing_init() {
-    TRACING.call_once(|| tracing_subscriber::fmt::init())
+pub fn tracing_init() {
+    TRACING.call_once(tracing_subscriber::fmt::init)
 }
-
-pub(crate) use assert_header_eq;

--- a/opensearch/tests/common/server.rs
+++ b/opensearch/tests/common/server.rs
@@ -32,7 +32,7 @@
 // Licensed under Apache License, Version 2.0
 // https://github.com/seanmonstar/reqwest/blob/master/LICENSE-APACHE
 
-use std::{net::SocketAddr, sync::mpsc as std_mpsc, thread, time::Duration};
+use std::{convert::identity, net::SocketAddr, sync::mpsc as std_mpsc, thread, time::Duration};
 
 use bytes::Bytes;
 use http_body_util::Empty;
@@ -166,12 +166,12 @@ impl MockServer {
         MockServerBuilder::default()
     }
 
-    pub fn start() -> anyhow::Result<MockServer> {
-        MockServerBuilder::default().start()
+    pub fn start() -> anyhow::Result<Self> {
+        Self::builder().start()
     }
 
     pub fn client(&self) -> OpenSearch {
-        self.client_builder().build()
+        self.client_with(identity)
     }
 
     pub fn client_with(

--- a/opensearch/tests/common/server.rs
+++ b/opensearch/tests/common/server.rs
@@ -32,47 +32,171 @@
 // Licensed under Apache License, Version 2.0
 // https://github.com/seanmonstar/reqwest/blob/master/LICENSE-APACHE
 
-use std::{
-    convert::Infallible,
-    future::Future,
-    net::{self, SocketAddr},
-    sync::mpsc as std_mpsc,
-    thread,
-    time::Duration,
-};
+use std::{net::SocketAddr, sync::mpsc as std_mpsc, thread, time::Duration};
 
 use bytes::Bytes;
 use http_body_util::Empty;
 use hyper::{
-    body::{Body, Incoming},
-    server::conn::http1,
-    service::service_fn,
-    Request, Response,
+    body::Incoming, server::conn::http1, service::service_fn, HeaderMap, Method, Request, Response,
+    Uri,
 };
 use hyper_util::rt::TokioIo;
+use opensearch::{http::transport::TransportBuilder, OpenSearch};
 use tokio::{
     net::{TcpListener, TcpStream},
-    sync::{broadcast, mpsc},
+    pin, runtime, select,
+    sync::{mpsc, watch},
+    task,
+    time::sleep,
 };
 
-use tokio::runtime;
+use super::client::TestClientBuilder;
 
-pub struct Server {
-    addr: net::SocketAddr,
-    panic_rx: std_mpsc::Receiver<()>,
-    shutdown_tx: Option<broadcast::Sender<()>>,
+#[derive(Clone)]
+struct RequestState {
+    requests_tx: mpsc::UnboundedSender<ReceivedRequest>,
+    response_delay: Option<Duration>,
+    shutdown_rx: watch::Receiver<bool>,
 }
 
-impl Server {
-    pub fn addr(&self) -> net::SocketAddr {
-        self.addr
+#[derive(Default)]
+pub struct MockServerBuilder {
+    response_delay: Option<Duration>,
+}
+
+impl MockServerBuilder {
+    pub fn response_delay(mut self, delay: Duration) -> Self {
+        self.response_delay = Some(delay);
+        self
+    }
+
+    async fn handle_request(
+        req: Request<Incoming>,
+        state: RequestState,
+    ) -> anyhow::Result<Response<Empty<Bytes>>> {
+        state.requests_tx.send(req.into())?;
+        if let Some(response_delay) = state.response_delay {
+            sleep(response_delay).await;
+        }
+        Ok(Default::default())
+    }
+
+    async fn serve_connection(io: TokioIo<TcpStream>, state: RequestState) {
+        let mut shutdown_rx = state.shutdown_rx.clone();
+        let conn = http1::Builder::new().serve_connection(
+            io,
+            service_fn(move |req| Self::handle_request(req, state.clone())),
+        );
+        pin!(conn);
+        select! {
+            _ = conn.as_mut() => {},
+            _ = shutdown_rx.changed() => conn.as_mut().graceful_shutdown()
+        }
+    }
+
+    async fn serve(listener: TcpListener, state: RequestState) -> anyhow::Result<()> {
+        let mut shutdown_rx = state.shutdown_rx.clone();
+        loop {
+            let (stream, _) = tokio::select! {
+                res = listener.accept() => res?,
+                _ = shutdown_rx.changed() => break
+            };
+            let io = TokioIo::new(stream);
+
+            task::spawn(Self::serve_connection(io, state.clone()));
+        }
+        Ok(())
+    }
+
+    fn start_inner(self, thread_name: String) -> anyhow::Result<MockServer> {
+        let rt = runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+        let _ = rt.enter();
+
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let (requests_tx, requests_rx) = mpsc::unbounded_channel();
+        let listener = rt.block_on(TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0))))?;
+        let addr = listener.local_addr()?;
+
+        let srv = Self::serve(
+            listener,
+            RequestState {
+                requests_tx,
+                response_delay: self.response_delay,
+                shutdown_rx,
+            },
+        );
+
+        let (panic_tx, panic_rx) = std_mpsc::channel();
+        thread::Builder::new()
+            .name(format!("test({})-support-server", thread_name))
+            .spawn(move || {
+                rt.block_on(srv).unwrap();
+                let _ = panic_tx.send(());
+            })?;
+
+        Ok(MockServer {
+            uri: format!("http://{}", addr),
+            requests_rx,
+            panic_rx,
+            shutdown_tx: Some(shutdown_tx),
+        })
+    }
+
+    pub fn start(self) -> anyhow::Result<MockServer> {
+        let thread_name = thread::current().name().unwrap_or("<unknown>").to_owned();
+
+        match thread::spawn(move || self.start_inner(thread_name)).join() {
+            Ok(r) => r,
+            Err(e) => Err(anyhow::anyhow!("MockServer startup panicked: {:?}", e)),
+        }
     }
 }
 
-impl Drop for Server {
+pub struct MockServer {
+    uri: String,
+    requests_rx: mpsc::UnboundedReceiver<ReceivedRequest>,
+    panic_rx: std_mpsc::Receiver<()>,
+    shutdown_tx: Option<watch::Sender<bool>>,
+}
+
+impl MockServer {
+    pub fn builder() -> MockServerBuilder {
+        MockServerBuilder::default()
+    }
+
+    pub fn start() -> anyhow::Result<MockServer> {
+        MockServerBuilder::default().start()
+    }
+
+    pub fn client(&self) -> OpenSearch {
+        self.client_builder().build()
+    }
+
+    pub fn client_with(
+        &self,
+        configurator: impl FnOnce(TransportBuilder) -> TransportBuilder,
+    ) -> OpenSearch {
+        self.client_builder().with(configurator).build()
+    }
+
+    pub fn client_builder(&self) -> TestClientBuilder {
+        super::client::builder_with_url(&self.uri)
+    }
+
+    pub async fn received_request(&mut self) -> anyhow::Result<ReceivedRequest> {
+        self.requests_rx
+            .recv()
+            .await
+            .ok_or_else(|| anyhow::anyhow!("no request received"))
+    }
+}
+
+impl Drop for MockServer {
     fn drop(&mut self) {
         if let Some(tx) = self.shutdown_tx.take() {
-            tx.send(()).unwrap();
+            tx.send(true).unwrap();
         }
 
         if !::std::thread::panicking() {
@@ -83,90 +207,36 @@ impl Drop for Server {
     }
 }
 
-pub fn http<F, Fut, B>(func: F) -> Server
-where
-    F: Fn(Request<Incoming>) -> Fut + Clone + Send + 'static,
-    Fut: Future<Output = Response<B>> + Send + 'static,
-    B: Body + Send + 'static,
-    B::Data: Send,
-    B::Error: std::error::Error + Send + Sync,
-{
-    let thread_name = thread::current().name().unwrap_or("<unknown>").to_owned();
-
-    thread::spawn(move || {
-        let rt = runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("new rt");
-        let _ = rt.enter();
-
-        let (shutdown_tx, mut shutdown_rx) = broadcast::channel(1);
-        let listener = rt
-            .block_on(TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0))))
-            .unwrap();
-        let addr = listener.local_addr().unwrap();
-
-        let srv = async move {
-            loop {
-                let (stream, _) = tokio::select! {
-                    res = listener.accept() => res?,
-                    _ = shutdown_rx.recv() => break
-                };
-                let io = TokioIo::new(stream);
-
-                let mut func = func.clone();
-                let mut shutdown_rx = shutdown_rx.resubscribe();
-
-                tokio::task::spawn(async move {
-                    let conn = http1::Builder::new().serve_connection(
-                        io,
-                        service_fn(move |req| {
-                            let func = func.clone();
-                            async move { Ok::<_, Infallible>(func(req).await) }
-                        }),
-                    );
-                    tokio::pin!(conn);
-                    tokio::select! {
-                        res = conn.as_mut() => {},
-                        _ = shutdown_rx.recv() => conn.as_mut().graceful_shutdown()
-                    }
-                });
-            }
-            Ok::<(), anyhow::Error>(())
-        };
-
-        let (panic_tx, panic_rx) = std_mpsc::channel();
-        let thread_name = format!("test({})-support-server", thread_name);
-        thread::Builder::new()
-            .name(thread_name)
-            .spawn(move || {
-                rt.block_on(srv).unwrap();
-                let _ = panic_tx.send(());
-            })
-            .expect("thread spawn");
-
-        Server {
-            addr,
-            panic_rx,
-            shutdown_tx: Some(shutdown_tx),
-        }
-    })
-    .join()
-    .unwrap()
+pub struct ReceivedRequest {
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
 }
 
-pub fn capturing_http() -> (Server, mpsc::UnboundedReceiver<Request<Incoming>>) {
-    let (tx, rx) = mpsc::unbounded_channel();
-    let server = http(move |req| {
-        let tx = tx.clone();
-        async move {
-            tx.send(req).unwrap();
-            empty_response()
-        }
-    });
-    (server, rx)
+impl ReceivedRequest {
+    pub fn method(&self) -> &Method {
+        &self.method
+    }
+
+    pub fn path(&self) -> &str {
+        self.uri.path()
+    }
+
+    pub fn query(&self) -> Option<&str> {
+        self.uri.query()
+    }
+
+    pub fn header(&self, name: &str) -> Option<&str> {
+        self.headers.get(name).and_then(|v| v.to_str().ok())
+    }
 }
 
-pub fn empty_response() -> Response<Empty<Bytes>> {
-    Default::default()
+impl From<Request<Incoming>> for ReceivedRequest {
+    fn from(req: Request<Incoming>) -> Self {
+        ReceivedRequest {
+            method: req.method().clone(),
+            uri: req.uri().clone(),
+            headers: req.headers().clone(),
+        }
+    }
 }

--- a/opensearch/tests/error.rs
+++ b/opensearch/tests/error.rs
@@ -38,8 +38,7 @@ use serde_json::{json, Value};
 /// Responses in the range 400-599 return Response body
 #[tokio::test]
 async fn bad_request_returns_response() -> anyhow::Result<()> {
-    let client = client::create_default();
-    let response = client
+    let response = client::create()
         .explain(ExplainParts::IndexId("non_existent_index", "id"))
         .body(json!({}))
         .send()
@@ -63,8 +62,7 @@ async fn bad_request_returns_response() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn deserialize_exception() -> anyhow::Result<()> {
-    let client = client::create_default();
-    let response = client
+    let response = client::create()
         .explain(ExplainParts::IndexId("non_existent_index", "id"))
         .error_trace(true)
         .body(json!({}))

--- a/yaml_test_runner/src/generator.rs
+++ b/yaml_test_runner/src/generator.rs
@@ -204,7 +204,7 @@ impl<'a> YamlTests<'a> {
 
     fn should_skip_suite(&self) -> Option<String> {
         if self.should_skip_test("*") {
-            Some(format!("it's included in skip.yml"))
+            Some("it's included in skip.yml".into())
         } else if let Some(setup) = &self.setup {
             setup
                 .steps
@@ -508,7 +508,7 @@ fn write_mod_files(generated_dir: &Path, toplevel: bool) -> anyhow::Result<()> {
     mods.sort();
 
     let path = generated_dir.join("mod.rs");
-    let mut file = File::create(&path)?;
+    let mut file = File::create(path)?;
     let generated_mods: String = mods.join("\n");
     file.write_all(generated_mods.as_bytes())?;
     Ok(())

--- a/yaml_test_runner/src/github.rs
+++ b/yaml_test_runner/src/github.rs
@@ -66,7 +66,7 @@ pub fn download_test_suites(branch: &str, download_dir: &Path) -> anyhow::Result
         .build()
         .unwrap();
 
-    let response = client.get(&url).send()?;
+    let response = client.get(url).send()?;
     let tar = GzDecoder::new(response);
     let mut archive = Archive::new(tar);
 

--- a/yaml_test_runner/tests/common/macros.rs
+++ b/yaml_test_runner/tests/common/macros.rs
@@ -132,9 +132,9 @@ macro_rules! assert_match {
 macro_rules! assert_numeric_match {
     ($expected:expr, $actual:expr) => {{
         if $expected.is_i64() {
-            crate::assert_match!($expected, $actual);
+            $crate::assert_match!($expected, $actual);
         } else {
-            crate::assert_match!($expected, $actual as f64);
+            $crate::assert_match!($expected, $actual as f64);
         }
     }};
 }


### PR DESCRIPTION
### Description
Refactors the mock HTTP server tests to simplify the test code.

Splitting up parts of #132 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
