### PR TITLE
Refactor error types to use `thiserror` and internalize `BuildError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+### ⚠️ Breaking Changes ⚠️
+- Internalized the `BuildError` type, consolidating on the `Error` type ([#228](https://github.com/opensearch-project/opensearch-rs/pull/228))
 
 ### Added
 

--- a/opensearch/Cargo.toml
+++ b/opensearch/Cargo.toml
@@ -39,6 +39,7 @@ url = "2.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_with = "3"
+thiserror = "1"
 void = "1.0.2"
 aws-credential-types = { version = "1", optional = true }
 aws-sigv4 = { version = "1", optional = true }

--- a/opensearch/src/auth.rs
+++ b/opensearch/src/auth.rs
@@ -97,11 +97,11 @@ impl std::convert::TryFrom<&aws_types::SdkConfig> for Credentials {
     fn try_from(value: &aws_types::SdkConfig) -> Result<Self, Self::Error> {
         let credentials = value
             .credentials_provider()
-            .ok_or_else(|| super::error::lib("SdkConfig does not have a credentials_provider"))?
+            .ok_or(crate::http::aws_auth::AwsSigV4Error::MissingCredentialsProvider)?
             .clone();
         let region = value
             .region()
-            .ok_or_else(|| super::error::lib("SdkConfig does not have a region"))?
+            .ok_or(crate::http::aws_auth::AwsSigV4Error::MissingRegion)?
             .clone();
         Ok(Credentials::AwsSigV4(credentials, region))
     }

--- a/opensearch/src/cert.rs
+++ b/opensearch/src/cert.rs
@@ -233,11 +233,15 @@ impl Certificate {
                 END_CERTIFICATE if begin => {
                     begin = false;
                     cert.push(line);
-                    certs.push(
-                        reqwest::Certificate::from_pem(cert.join("\n").as_bytes())
-                            .map_err(CertificateError::MalformedCertificate)?,
-                    );
-                    cert = Vec::new();
+
+                    {
+                        let cert = reqwest::Certificate::from_pem(cert.join("\n").as_bytes())
+                            .map_err(CertificateError::MalformedCertificate)?;
+
+                        certs.push(cert);
+                    }
+
+                    cert.clear();
                 }
                 _ if begin => cert.push(line),
                 _ => {}

--- a/opensearch/src/error.rs
+++ b/opensearch/src/error.rs
@@ -58,15 +58,15 @@ where
 }
 
 #[derive(Debug, thiserror::Error)]
-pub(crate) enum Kind {
+enum Kind {
     #[error("transport builder error: {0}")]
     TransportBuilder(#[from] transport::BuildError),
 
     #[error("certificate error: {0}")]
     Certificate(#[from] CertificateError),
 
-    #[error("reqwest error: {0}")]
-    Reqwest(#[from] reqwest::Error),
+    #[error("http error: {0}")]
+    Http(#[from] reqwest::Error),
 
     #[error("URL parse error: {0}")]
     UrlParse(#[from] url::ParseError),
@@ -82,11 +82,13 @@ pub(crate) enum Kind {
     AwsSigV4(#[from] crate::http::aws_auth::AwsSigV4Error),
 }
 
+use Kind::*;
+
 impl Error {
     /// The status code, if the error was generated from a response
     pub fn status_code(&self) -> Option<StatusCode> {
         match &self.0 {
-            Kind::Reqwest(err) => err.status(),
+            Http(err) => err.status(),
             _ => None,
         }
     }
@@ -94,13 +96,13 @@ impl Error {
     /// Returns true if the error is related to a timeout
     pub fn is_timeout(&self) -> bool {
         match &self.0 {
-            Kind::Reqwest(err) => err.is_timeout(),
+            Http(err) => err.is_timeout(),
             _ => false,
         }
     }
 
     /// Returns true if the error is related to serialization or deserialization
     pub fn is_json(&self) -> bool {
-        matches!(self.0, Kind::Json(_))
+        matches!(self.0, Json(_))
     }
 }

--- a/opensearch/src/http/mod.rs
+++ b/opensearch/src/http/mod.rs
@@ -38,7 +38,7 @@ pub mod request;
 pub mod response;
 pub mod transport;
 
-pub use reqwest::StatusCode;
+pub use reqwest::{self, Request, StatusCode};
 pub use url::Url;
 
 /// Http methods supported by OpenSearch

--- a/opensearch/src/http/transport.rs
+++ b/opensearch/src/http/transport.rs
@@ -36,6 +36,7 @@ use crate::auth::ClientCertificate;
 use crate::cert::CertificateValidation;
 use crate::{
     auth::Credentials,
+    cert::CertificateError,
     error::Error,
     http::{
         headers::{
@@ -54,60 +55,15 @@ use bytes::BytesMut;
 use dyn_clone::clone_trait_object;
 use lazy_static::lazy_static;
 use serde::Serialize;
-use std::{
-    error, fmt,
-    fmt::Debug,
-    io::{self, Write},
-    time::Duration,
-};
+use std::{fmt::Debug, io::Write, time::Duration};
 use url::Url;
 
-/// Error that can occur when building a [Transport]
-#[derive(Debug)]
-pub enum BuildError {
-    /// IO error
-    Io(io::Error),
-
-    /// Certificate error
-    Cert(reqwest::Error),
-}
-
-impl From<io::Error> for BuildError {
-    fn from(err: io::Error) -> BuildError {
-        BuildError::Io(err)
-    }
-}
-
-impl From<reqwest::Error> for BuildError {
-    fn from(err: reqwest::Error) -> BuildError {
-        BuildError::Cert(err)
-    }
-}
-
-impl error::Error for BuildError {
-    #[allow(warnings)]
-    fn description(&self) -> &str {
-        match *self {
-            BuildError::Io(ref err) => err.description(),
-            BuildError::Cert(ref err) => err.description(),
-        }
-    }
-
-    fn cause(&self) -> Option<&dyn error::Error> {
-        match *self {
-            BuildError::Io(ref err) => Some(err as &dyn error::Error),
-            BuildError::Cert(ref err) => Some(err as &dyn error::Error),
-        }
-    }
-}
-
-impl fmt::Display for BuildError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            BuildError::Io(ref err) => fmt::Display::fmt(err, f),
-            BuildError::Cert(ref err) => fmt::Display::fmt(err, f),
-        }
-    }
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum BuildError {
+    #[error("proxy configuration error: {0}")]
+    Proxy(#[source] reqwest::Error),
+    #[error("reqwest configuration error: {0}")]
+    Reqwest(#[source] reqwest::Error),
 }
 
 /// Default address to OpenSearch running on `http://localhost:9200`
@@ -270,7 +226,7 @@ impl TransportBuilder {
     }
 
     /// Builds a [Transport] to use to send API calls to OpenSearch.
-    pub fn build(self) -> Result<Transport, BuildError> {
+    pub fn build(self) -> Result<Transport, Error> {
         let mut client_builder = self.client_builder;
 
         if let Some(t) = self.timeout {
@@ -287,12 +243,14 @@ impl TransportBuilder {
                             Some(pass) => pass.as_str(),
                             None => "",
                         };
-                        let pkcs12 = reqwest::Identity::from_pkcs12_der(b, password)?;
+                        let pkcs12 = reqwest::Identity::from_pkcs12_der(b, password)
+                            .map_err(CertificateError::MalformedCertificate)?;
                         client_builder.identity(pkcs12)
                     }
                     #[cfg(feature = "rustls-tls")]
                     ClientCertificate::Pem(b) => {
-                        let pem = reqwest::Identity::from_pem(b)?;
+                        let pem = reqwest::Identity::from_pem(b)
+                            .map_err(CertificateError::MalformedCertificate)?;
                         client_builder.identity(pem)
                     }
                 }
@@ -322,7 +280,7 @@ impl TransportBuilder {
         if self.disable_proxy {
             client_builder = client_builder.no_proxy();
         } else if let Some(url) = self.proxy {
-            let mut proxy = reqwest::Proxy::all(url)?;
+            let mut proxy = reqwest::Proxy::all(url).map_err(BuildError::Proxy)?;
             if let Some(c) = self.proxy_credentials {
                 proxy = match c {
                     Credentials::Basic(u, p) => proxy.basic_auth(&u, &p),
@@ -332,7 +290,7 @@ impl TransportBuilder {
             client_builder = client_builder.proxy(proxy);
         }
 
-        let client = client_builder.build()?;
+        let client = client_builder.build().map_err(BuildError::Reqwest)?;
         Ok(Transport {
             client,
             conn_pool: self.conn_pool,
@@ -505,8 +463,7 @@ impl Transport {
                 region,
                 &self.sigv4_time_source,
             )
-            .await
-            .map_err(|e| crate::error::lib(format!("AWSV4 Signing Failed: {}", e)))?;
+            .await?;
         }
 
         let response = self.client.execute(request).await;


### PR DESCRIPTION
### Description
Refactors the error types to use `thiserror` and internalize the `BuildError` type.

Split from #132.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
