### PR TITLE
Replace remaining references to Elasticsearch with OpenSearch

### DIFF
--- a/api_generator/rest_specs/text_structure.find_structure.json
+++ b/api_generator/rest_specs/text_structure.find_structure.json
@@ -2,7 +2,7 @@
   "text_structure.find_structure":{
     "documentation":{
       "url":"https://opensearch.org/docs/",
-      "description":"Finds the structure of a text file. The text file must contain data that is suitable to be ingested into Elasticsearch."
+      "description":"Finds the structure of a text file. The text file must contain data that is suitable to be ingested into OpenSearch."
     },
     "stability":"experimental",
     "visibility":"public",

--- a/api_generator/src/generator/code_gen/root.rs
+++ b/api_generator/src/generator/code_gen/root.rs
@@ -23,7 +23,7 @@ use proc_macro2::TokenStream;
 use quote::{quote, TokenStreamExt};
 use std::path::Path;
 
-/// Generates the source code for the methods on the root of Elasticsearch
+/// Generates the source code for the methods on the root of OpenSearch
 pub fn generate(api: &Api, docs_dir: &Path) -> anyhow::Result<String> {
     let mut tokens = TokenStream::new();
     tokens.append_all(use_declarations());

--- a/api_generator/src/rest_spec/mod.rs
+++ b/api_generator/src/rest_spec/mod.rs
@@ -27,7 +27,7 @@ use tar::{Archive, Entry};
 
 pub fn download_specs(branch: &str, download_dir: &Path) -> anyhow::Result<()> {
     let url = format!(
-        "https://api.github.com/repos/elastic/elasticsearch/tarball/{}",
+        "https://api.github.com/repos/opensearch-project/opensearch/tarball/{}",
         branch
     );
 

--- a/opensearch/src/error.rs
+++ b/opensearch/src/error.rs
@@ -38,7 +38,7 @@ use std::{error, fmt, io};
 /// An error with the client.
 ///
 /// Errors that can occur include IO and parsing errors, as well as specific
-/// errors from Elasticsearch and internal errors from the client.
+/// errors from OpenSearch and internal errors from the client.
 #[derive(Debug)]
 pub struct Error {
     kind: Kind,

--- a/opensearch/src/http/headers.rs
+++ b/opensearch/src/http/headers.rs
@@ -28,7 +28,7 @@
  * GitHub history for details.
  */
 
-//! HTTP header names and values, including those specific to Elasticsearch
+//! HTTP header names and values, including those specific to OpenSearch
 
 pub use reqwest::header::*;
 

--- a/opensearch/src/http/mod.rs
+++ b/opensearch/src/http/mod.rs
@@ -41,7 +41,7 @@ pub mod transport;
 pub use reqwest::StatusCode;
 pub use url::Url;
 
-/// Http methods supported by Elasticsearch
+/// Http methods supported by OpenSearch
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Method {
     /// get

--- a/opensearch/src/http/request.rs
+++ b/opensearch/src/http/request.rs
@@ -45,7 +45,7 @@ pub(crate) const PARTS_ENCODED: &AsciiSet = &percent_encoding::NON_ALPHANUMERIC
 
 /// Body of an API call.
 ///
-/// Some Elasticsearch APIs accept a body as part of the API call. Most APIs
+/// Some OpenSearch APIs accept a body as part of the API call. Most APIs
 /// expect JSON, however, there are some APIs that expect newline-delimited JSON (NDJSON).
 /// The [Body] trait allows modelling different API body implementations.
 pub trait Body {

--- a/opensearch/src/http/response.rs
+++ b/opensearch/src/http/response.rs
@@ -43,14 +43,14 @@ use serde_json::Value;
 use std::{collections::BTreeMap, fmt, str::FromStr};
 use void::Void;
 
-/// A response from Elasticsearch
+/// A response from OpenSearch
 pub struct Response {
     response: reqwest::Response,
     method: Method,
 }
 
 impl Response {
-    /// Creates a new instance of an Elasticsearch response
+    /// Creates a new instance of an OpenSearch response
     pub fn new(response: reqwest::Response, method: Method) -> Self {
         Self { response, method }
     }
@@ -75,7 +75,7 @@ impl Response {
             .unwrap()
     }
 
-    /// Turn the response into an [Error] if Elasticsearch returned an error.
+    /// Turn the response into an [Error] if OpenSearch returned an error.
     pub fn error_for_status_code(self) -> Result<Self, ClientError> {
         match self.response.error_for_status_ref() {
             Ok(_) => Ok(self),
@@ -83,7 +83,7 @@ impl Response {
         }
     }
 
-    /// Turn the response into an [Error] if Elasticsearch returned an error.
+    /// Turn the response into an [Error] if OpenSearch returned an error.
     pub fn error_for_status_code_ref(&self) -> Result<&Self, ClientError> {
         match self.response.error_for_status_ref() {
             Ok(_) => Ok(self),
@@ -92,7 +92,7 @@ impl Response {
     }
 
     /// Asynchronously reads the response body into an [Exception] if
-    /// Elasticsearch returned a HTTP status code in the 400-599 range.
+    /// OpenSearch returned a HTTP status code in the 400-599 range.
     ///
     /// Reading the response body consumes `self`
     pub async fn exception(self) -> Result<Option<Exception>, ClientError> {
@@ -153,7 +153,7 @@ impl Response {
 
     /// Gets the Deprecation warning response headers
     ///
-    /// Deprecation headers signal the use of Elasticsearch functionality
+    /// Deprecation headers signal the use of OpenSearch functionality
     /// or features that are deprecated and will be removed in a future release.
     pub fn warning_headers(&self) -> impl Iterator<Item = &str> {
         self.response.headers().get_all("Warning").iter().map(|w| {
@@ -176,7 +176,7 @@ impl fmt::Debug for Response {
     }
 }
 
-/// An exception raised by Elasticsearch.
+/// An exception raised by OpenSearch.
 ///
 /// Contains details that indicate why the exception was raised which can help to determine
 /// what subsequent action to take.
@@ -200,7 +200,7 @@ impl Exception {
     }
 }
 
-/// Details about the exception raised by Elasticsearch
+/// Details about the exception raised by OpenSearch
 #[serde_with::skip_serializing_none]
 #[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
 pub struct Error {
@@ -265,14 +265,14 @@ impl Error {
 
     /// Additional details about the cause.
     ///
-    /// Elasticsearch can return additional details about an exception, depending
+    /// OpenSearch can return additional details about an exception, depending
     /// on context, which do not map to fields on [Error]. These are collected here
     pub fn additional_details(&self) -> &BTreeMap<String, Value> {
         &self.additional_details
     }
 }
 
-// An error in an Elasticsearch exception can be returned as a simple message string only, or
+// An error in an OpenSearch exception can be returned as a simple message string only, or
 // as a JSON object. Handle both cases by corralling the simple message into the reason field
 impl FromStr for Error {
     type Err = Void;
@@ -370,7 +370,7 @@ impl Cause {
 
     /// Additional details about the cause.
     ///
-    /// Elasticsearch can return additional details about an exception, depending
+    /// OpenSearch can return additional details about an exception, depending
     /// on context, which do not map to fields on [Error]. These are collected here
     pub fn additional_details(&self) -> &BTreeMap<String, Value> {
         &self.additional_details

--- a/opensearch/src/http/transport.rs
+++ b/opensearch/src/http/transport.rs
@@ -269,7 +269,7 @@ impl TransportBuilder {
         self
     }
 
-    /// Builds a [Transport] to use to send API calls to Elasticsearch.
+    /// Builds a [Transport] to use to send API calls to OpenSearch.
     pub fn build(self) -> Result<Transport, BuildError> {
         let mut client_builder = self.client_builder;
 
@@ -353,7 +353,7 @@ impl Default for TransportBuilder {
     }
 }
 
-/// A connection to an Elasticsearch node, used to send an API request
+/// A connection to an OpenSearch node, used to send an API request
 #[derive(Debug, Clone)]
 pub struct Connection {
     url: Url,
@@ -374,7 +374,7 @@ impl Connection {
     }
 }
 
-/// A HTTP transport responsible for making the API requests to Elasticsearch,
+/// A HTTP transport responsible for making the API requests to OpenSearch,
 /// using a [Connection] selected from a [ConnectionPool]
 #[derive(Debug, Clone)]
 pub struct Transport {
@@ -523,7 +523,7 @@ impl Default for Transport {
     }
 }
 
-/// A pool of [Connection]s, used to make API calls to Elasticsearch.
+/// A pool of [Connection]s, used to make API calls to OpenSearch.
 ///
 /// A [ConnectionPool] manages the connections, with different implementations determining how
 /// to get the next [Connection]. The simplest type of [ConnectionPool] is [SingleNodeConnectionPool],
@@ -536,7 +536,7 @@ pub trait ConnectionPool: Debug + dyn_clone::DynClone + Sync + Send {
 
 clone_trait_object!(ConnectionPool);
 
-/// A connection pool that manages the single connection to an Elasticsearch cluster.
+/// A connection pool that manages the single connection to an OpenSearch cluster.
 #[derive(Debug, Clone)]
 pub struct SingleNodeConnectionPool {
     connection: Connection,

--- a/opensearch/src/root/bulk.rs
+++ b/opensearch/src/root/bulk.rs
@@ -127,7 +127,7 @@ impl Serialize for BulkHeader {
 /// ops.push(BulkOperation::index(json!({
 ///         "user": "kimchy",
 ///         "post_date": "2009-11-15T00:00:00Z",
-///         "message": "Trying out Elasticsearch, so far so good?"
+///         "message": "Trying out OpenSearch, so far so good?"
 ///     }))
 ///     .id("1")
 ///     .pipeline("process_tweet")
@@ -307,7 +307,7 @@ impl<B> BulkIndexOperation<B> {
 
     /// Specify the id for the document
     ///
-    /// If an id is not specified, Elasticsearch will generate an id for the document
+    /// If an id is not specified, OpenSearch will generate an id for the document
     /// which will be returned in the response.
     pub fn id<S>(mut self, id: S) -> Self
     where

--- a/opensearch/src/text_structure.rs
+++ b/opensearch/src/text_structure.rs
@@ -62,7 +62,7 @@ impl TextStructureFindStructureParts {
         }
     }
 }
-#[doc = "Builder for the [Text Structure Find Structure API](https://opensearch.org/docs/)\n\nFinds the structure of a text file. The text file must contain data that is suitable to be ingested into Elasticsearch."]
+#[doc = "Builder for the [Text Structure Find Structure API](https://opensearch.org/docs/)\n\nFinds the structure of a text file. The text file must contain data that is suitable to be ingested into OpenSearch."]
 #[doc = "&nbsp;\n# Optional, experimental\nThis requires the `experimental-apis` feature. Can have breaking changes in future\nversions or might even be removed entirely.\n        "]
 #[cfg(feature = "experimental-apis")]
 #[derive(Clone, Debug)]
@@ -342,7 +342,7 @@ impl<'a> TextStructure<'a> {
     pub fn transport(&self) -> &Transport {
         self.transport
     }
-    #[doc = "[Text Structure Find Structure API](https://opensearch.org/docs/)\n\nFinds the structure of a text file. The text file must contain data that is suitable to be ingested into Elasticsearch."]
+    #[doc = "[Text Structure Find Structure API](https://opensearch.org/docs/)\n\nFinds the structure of a text file. The text file must contain data that is suitable to be ingested into OpenSearch."]
     #[doc = "&nbsp;\n# Optional, experimental\nThis requires the `experimental-apis` feature. Can have breaking changes in future\nversions or might even be removed entirely.\n        "]
     #[cfg(feature = "experimental-apis")]
     pub fn find_structure<'b>(&'a self) -> TextStructureFindStructure<'a, 'b, ()> {

--- a/opensearch/tests/auth.rs
+++ b/opensearch/tests/auth.rs
@@ -104,7 +104,7 @@ async fn bearer_header() -> anyhow::Result<()> {
     Ok(())
 }
 
-// TODO: test PKI authentication. Could configure a HttpsConnector, maybe using https://github.com/sfackler/hyper-openssl?, or send to PKI configured Elasticsearch.
+// TODO: test PKI authentication. Could configure a HttpsConnector, maybe using https://github.com/sfackler/hyper-openssl?, or send to PKI configured OpenSearch.
 //#[tokio::test]
 //async fn client_certificate() -> anyhow::Result<()> {
 //    let server = server::http(move |req| {

--- a/opensearch/tests/common/client.rs
+++ b/opensearch/tests/common/client.rs
@@ -45,7 +45,7 @@ use serde_json::json;
 use sysinfo::{ProcessRefreshKind, RefreshKind, System, SystemExt};
 use url::Url;
 
-/// Gets the address to the Elasticsearch instance from environment variables
+/// Gets the address to the OpenSearch instance from environment variables
 /// and assumes an instance running locally on the default port otherwise
 pub fn cluster_addr() -> String {
     match std::env::var("OPENSEARCH_URL") {


### PR DESCRIPTION
### Description
Replace remaining references to Elasticsearch with OpenSearch

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
