### PR TITLE
Default admin password as admin

### DIFF
--- a/.github/actions/start-opensearch/action.yml
+++ b/.github/actions/start-opensearch/action.yml
@@ -39,7 +39,7 @@ runs:
 
         if [[ -d "$OPENSEARCH_HOME/plugins/opensearch-security" ]]; then
           if [[ "$SECURED" == "true" ]]; then
-            if [ "$COMPARE_VERSION" != "$OPENSEARCH_REQUIRED_VERSION" ]; then
+            if [ "$COMPARE_VERSION" == "$OPENSEARCH_REQUIRED_VERSION" ]; then
               bash $OPENSEARCH_HOME/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s -t
             else
               bash $OPENSEARCH_HOME/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s

--- a/.github/actions/start-opensearch/action.yml
+++ b/.github/actions/start-opensearch/action.yml
@@ -26,6 +26,7 @@ runs:
         fi
         OPENSEARCH_HOME=$(realpath ./opensearch-*)
         OPENSEARCH_JAVA_OPTS="-Djava.net.preferIPv4Stack=true"
+        OPENSEARCH_INITIAL_ADMIN_PASSWORD=admin
 
         url="http://localhost:9200"
         cp ./client/.ci/opensearch/opensearch.yml $OPENSEARCH_HOME/config/
@@ -34,7 +35,7 @@ runs:
 
         if [[ -d "$OPENSEARCH_HOME/plugins/opensearch-security" ]]; then
           if [[ "$SECURED" == "true" ]]; then
-            bash $OPENSEARCH_HOME/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s
+            bash $OPENSEARCH_HOME/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s -t
             sed -i.bak -e 's/plugins.security.audit.type:.*/plugins.security.audit.type: log4j/' $OPENSEARCH_HOME/config/opensearch.yml
             cp ./client/.ci/opensearch/*.pem $OPENSEARCH_HOME/config/
             url="https://localhost:9200"

--- a/.github/actions/start-opensearch/action.yml
+++ b/.github/actions/start-opensearch/action.yml
@@ -27,6 +27,9 @@ runs:
         OPENSEARCH_HOME=$(realpath ./opensearch-*)
         OPENSEARCH_JAVA_OPTS="-Djava.net.preferIPv4Stack=true"
         export OPENSEARCH_INITIAL_ADMIN_PASSWORD=admin
+        OPENSEARCH_REQUIRED_VERSION="2.12.0"
+        # Starting in 2.12.0, security demo configuration script requires an initial admin password
+        COMPARE_VERSION=`echo $OPENSEARCH_REQUIRED_VERSION $OPENSEARCH_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
 
         url="http://localhost:9200"
         cp ./client/.ci/opensearch/opensearch.yml $OPENSEARCH_HOME/config/
@@ -35,7 +38,11 @@ runs:
 
         if [[ -d "$OPENSEARCH_HOME/plugins/opensearch-security" ]]; then
           if [[ "$SECURED" == "true" ]]; then
-            bash $OPENSEARCH_HOME/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s -t
+            if [ "$COMPARE_VERSION" != "$OPENSEARCH_REQUIRED_VERSION" ]; then
+              bash $OPENSEARCH_HOME/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s -t
+            else
+              bash $OPENSEARCH_HOME/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s
+            fi
             sed -i.bak -e 's/plugins.security.audit.type:.*/plugins.security.audit.type: log4j/' $OPENSEARCH_HOME/config/opensearch.yml
             cp ./client/.ci/opensearch/*.pem $OPENSEARCH_HOME/config/
             url="https://localhost:9200"

--- a/.github/actions/start-opensearch/action.yml
+++ b/.github/actions/start-opensearch/action.yml
@@ -26,7 +26,6 @@ runs:
         fi
         OPENSEARCH_HOME=$(realpath ./opensearch-*)
         OPENSEARCH_JAVA_OPTS="-Djava.net.preferIPv4Stack=true"
-        OPENSEARCH_VERSION=$(cat $OPENSEARCH_HOME/plugins/opensearch-security/plugin-descriptor.properties | grep '^version=' | cut -d'=' -f 2)
         export OPENSEARCH_INITIAL_ADMIN_PASSWORD=admin
 
         url="http://localhost:9200"
@@ -36,6 +35,7 @@ runs:
 
         if [[ -d "$OPENSEARCH_HOME/plugins/opensearch-security" ]]; then
           if [[ "$SECURED" == "true" ]]; then
+            OPENSEARCH_VERSION=$(cat $OPENSEARCH_HOME/plugins/opensearch-security/plugin-descriptor.properties | grep '^version=' | cut -d'=' -f 2)
             OPENSEARCH_REQUIRED_VERSION="2.12.0"
             # Starting in 2.12.0, security demo configuration script requires an initial admin password
             COMPARE_VERSION=`echo $OPENSEARCH_REQUIRED_VERSION $OPENSEARCH_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`

--- a/.github/actions/start-opensearch/action.yml
+++ b/.github/actions/start-opensearch/action.yml
@@ -28,9 +28,6 @@ runs:
         OPENSEARCH_JAVA_OPTS="-Djava.net.preferIPv4Stack=true"
         OPENSEARCH_VERSION=$(cat $OPENSEARCH_HOME/plugins/opensearch-security/plugin-descriptor.properties | grep '^version=' | cut -d'=' -f 2)
         export OPENSEARCH_INITIAL_ADMIN_PASSWORD=admin
-        OPENSEARCH_REQUIRED_VERSION="2.12.0"
-        # Starting in 2.12.0, security demo configuration script requires an initial admin password
-        COMPARE_VERSION=`echo $OPENSEARCH_REQUIRED_VERSION $OPENSEARCH_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
 
         url="http://localhost:9200"
         cp ./client/.ci/opensearch/opensearch.yml $OPENSEARCH_HOME/config/
@@ -39,6 +36,9 @@ runs:
 
         if [[ -d "$OPENSEARCH_HOME/plugins/opensearch-security" ]]; then
           if [[ "$SECURED" == "true" ]]; then
+            OPENSEARCH_REQUIRED_VERSION="2.12.0"
+            # Starting in 2.12.0, security demo configuration script requires an initial admin password
+            COMPARE_VERSION=`echo $OPENSEARCH_REQUIRED_VERSION $OPENSEARCH_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
             if [ "$COMPARE_VERSION" == "$OPENSEARCH_REQUIRED_VERSION" ]; then
               bash $OPENSEARCH_HOME/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s -t
             else

--- a/.github/actions/start-opensearch/action.yml
+++ b/.github/actions/start-opensearch/action.yml
@@ -26,6 +26,7 @@ runs:
         fi
         OPENSEARCH_HOME=$(realpath ./opensearch-*)
         OPENSEARCH_JAVA_OPTS="-Djava.net.preferIPv4Stack=true"
+        OPENSEARCH_VERSION=$(cat $OPENSEARCH_HOME/plugins/opensearch-security/plugin-descriptor.properties | grep '^version=' | cut -d'=' -f 2)
         export OPENSEARCH_INITIAL_ADMIN_PASSWORD=admin
         OPENSEARCH_REQUIRED_VERSION="2.12.0"
         # Starting in 2.12.0, security demo configuration script requires an initial admin password

--- a/.github/actions/start-opensearch/action.yml
+++ b/.github/actions/start-opensearch/action.yml
@@ -26,7 +26,7 @@ runs:
         fi
         OPENSEARCH_HOME=$(realpath ./opensearch-*)
         OPENSEARCH_JAVA_OPTS="-Djava.net.preferIPv4Stack=true"
-        OPENSEARCH_INITIAL_ADMIN_PASSWORD=admin
+        export OPENSEARCH_INITIAL_ADMIN_PASSWORD=admin
 
         url="http://localhost:9200"
         cp ./client/.ci/opensearch/opensearch.yml $OPENSEARCH_HOME/config/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['1.1.0', '1.2.4', '1.3.4', '2.2.0', '2.4.0', '2.6.0', '2.8.0']
+        version: ['1.1.0', '1.2.4', '1.3.4', '2.2.0', '2.4.0', '2.6.0', '2.8.0', '2.12.0']
         secured: [true, false]
     steps:
       - name: Checkout Rust Client


### PR DESCRIPTION
### Description
Fixes the CI to pass in "admin" as the admin password if the version is >= 2.12. This is necessary since 2.12 and onwards requires an initial admin password to be set in order to run the security demo configuration.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
