### PR TITLE
[Backport 2.x] Update base64 requirement from 0.21 to 0.22 (#242)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `itertools` from 0.11.0 to 0.12.0
 - Bumps `hyper` from 0.14 to 1 in tests ([#221](https://github.com/opensearch-project/opensearch-rs/pull/221))
 - Bumps `sysinfo` from 0.29.0 to 0.30.5
+- Bumps `base64` from 0.21 to 0.22
 
 ### Changed
 

--- a/opensearch/Cargo.toml
+++ b/opensearch/Cargo.toml
@@ -29,7 +29,7 @@ rustls-tls = ["reqwest/rustls-tls"]
 aws-auth = ["aws-credential-types", "aws-sigv4", "aws-smithy-runtime-api", "aws-types"]
 
 [dependencies]
-base64 = "0.21"
+base64 = "0.22"
 bytes = "1.0"
 dyn-clone = "1"
 lazy_static = "1.4"

--- a/yaml_test_runner/Cargo.toml
+++ b/yaml_test_runner/Cargo.toml
@@ -13,7 +13,7 @@ opensearch = { path = "../opensearch", features = ["experimental-apis"]}
 api_generator = { path = "./../api_generator" }
 
 anyhow = "1.0"
-base64 = "0.21"
+base64 = "0.22"
 clap = "2"
 itertools = "0.12.0"
 Inflector = "0.11.4"


### PR DESCRIPTION
### Description
Backport 90cd340ee9decd27656efbbfd4eafad05fb00b7b from #242 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
