### PR TITLE
Add new bulk create constructor without optional _id field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 - Added middleware types to allow intercepting construction and handling of the underlying `reqwest` client & requests ([#232](https://github.com/opensearch-project/opensearch-rs/pull/232)) 
+- Added new BulkCreate operation constructor without providing optional `id` field ([#245](https://github.com/opensearch-project/opensearch-rs/pull/245))
 
 ### Dependencies
 - Bumps `aws-*` dependencies to `1` ([#219](https://github.com/opensearch-project/opensearch-rs/pull/219))

--- a/opensearch/src/root/bulk.rs
+++ b/opensearch/src/root/bulk.rs
@@ -179,9 +179,9 @@ where
         BulkCreateOperation::new(id, source)
     }
 
-    /// Creates a new instance of [bulk create operation](BulkCreateOperation) without explicit id
-    pub fn create_no_id(source: B) -> BulkCreateOperation<B> {
-        BulkCreateOperation::new_no_id(source)
+    /// Creates a new instance of [bulk create operation](BulkCreateOperation) without an explicit id
+    pub fn create_without_id(source: B) -> BulkCreateOperation<B> {
+        BulkCreateOperation::new_without_id(source)
     }
 
     /// Creates a new instance of a [bulk index operation](BulkIndexOperation)
@@ -250,8 +250,8 @@ impl<B> BulkCreateOperation<B> {
         }
     }
 
-    /// Creates a new instance of [BulkCreateOperation] without explicit id
-    pub fn new_no_id(source: B) -> Self {
+    /// Creates a new instance of [BulkCreateOperation] without an explicit id
+    pub fn new_without_id(source: B) -> Self {
         Self {
             operation: BulkOperation {
                 header: BulkHeader {
@@ -810,7 +810,7 @@ mod tests {
                 .routing("routing"),
         )?;
         ops.push(BulkOperation::create("2", CreateDoc { bar: "create" }))?;
-        ops.push(BulkOperation::create_no_id(CreateDoc { bar: "create" }))?;
+        ops.push(BulkOperation::create_without_id(CreateDoc { bar: "create" }))?;
         ops.push(BulkOperation::update("3", UpdateDoc { baz: "update" }))?;
         ops.push(BulkOperation::<()>::delete("4"))?;
 

--- a/opensearch/src/root/bulk.rs
+++ b/opensearch/src/root/bulk.rs
@@ -172,7 +172,7 @@ where
     B: Serialize,
 {
     /// Creates a new instance of a [bulk create operation](BulkCreateOperation)
-    pub fn create<S>(id: S, source: B) -> BulkCreateOperation<B>
+    pub fn create<S>(id: Option<S>, source: B) -> BulkCreateOperation<B>
     where
         S: Into<String>,
     {
@@ -180,8 +180,11 @@ where
     }
 
     /// Creates a new instance of a [bulk index operation](BulkIndexOperation)
-    pub fn index(source: B) -> BulkIndexOperation<B> {
-        BulkIndexOperation::new(source)
+    pub fn index<S>(id: Option<S>, source: B) -> BulkIndexOperation<B>
+    where
+        S: Into<String>,
+    {
+        BulkIndexOperation::new(id, source)
     }
 
     /// Creates a new instance of a [bulk delete operation](BulkDeleteOperation)
@@ -227,7 +230,7 @@ pub struct BulkCreateOperation<B> {
 
 impl<B> BulkCreateOperation<B> {
     /// Creates a new instance of [BulkCreateOperation]
-    pub fn new<S>(id: S, source: B) -> Self
+    pub fn new<S>(id: Option<S>, source: B) -> Self
     where
         S: Into<String>,
     {
@@ -236,7 +239,7 @@ impl<B> BulkCreateOperation<B> {
                 header: BulkHeader {
                     action: BulkAction::Create,
                     metadata: BulkMetadata {
-                        _id: Some(id.into()),
+                        _id: id.map(|_id| _id.into()),
                         ..Default::default()
                     },
                 },
@@ -291,12 +294,16 @@ pub struct BulkIndexOperation<B> {
 
 impl<B> BulkIndexOperation<B> {
     /// Creates a new instance of [BulkIndexOperation]
-    pub fn new(source: B) -> Self {
+    pub fn new<S>(id: Option<S>, source: B) -> Self
+    where
+        S: Into<String>,
+    {
         Self {
             operation: BulkOperation {
                 header: BulkHeader {
                     action: BulkAction::Index,
                     metadata: BulkMetadata {
+                        _id: id.map(|_id| _id.into()),
                         ..Default::default()
                     },
                 },
@@ -696,8 +703,7 @@ mod tests {
         let mut ops: Vec<BulkOperation<Value>> = Vec::with_capacity(4);
 
         ops.push(
-            BulkOperation::index(json!({ "foo": "index" }))
-                .id("1")
+            BulkOperation::index(Some("1"), json!({ "foo": "index" }))
                 .pipeline("pipeline")
                 .routing("routing")
                 .if_seq_no(1)
@@ -707,7 +713,7 @@ mod tests {
                 .into(),
         );
         ops.push(
-            BulkOperation::create("2", json!({ "bar": "create" }))
+            BulkOperation::create(Some("2"), json!({ "bar": "create" }))
                 .pipeline("pipeline")
                 .routing("routing")
                 .index("create_index")
@@ -782,13 +788,19 @@ mod tests {
         let mut ops = BulkOperations::new();
 
         ops.push(
-            BulkOperation::index(IndexDoc { foo: "index" })
-                .id("1")
+            BulkOperation::index(Some("1"), IndexDoc { foo: "index" })
                 .pipeline("pipeline")
                 .index("index_doc")
                 .routing("routing"),
         )?;
-        ops.push(BulkOperation::create("2", CreateDoc { bar: "create" }))?;
+        ops.push(BulkOperation::create(
+            Some("2"),
+            CreateDoc { bar: "create" },
+        ))?;
+        ops.push(BulkOperation::create(
+            None::<String>,
+            CreateDoc { bar: "create" },
+        ))?;
         ops.push(BulkOperation::update("3", UpdateDoc { baz: "update" }))?;
         ops.push(BulkOperation::<()>::delete("4"))?;
 
@@ -799,6 +811,8 @@ mod tests {
         expected.put_slice(b"{\"index\":{\"_index\":\"index_doc\",\"_id\":\"1\",\"pipeline\":\"pipeline\",\"routing\":\"routing\"}}\n");
         expected.put_slice(b"{\"foo\":\"index\"}\n");
         expected.put_slice(b"{\"create\":{\"_id\":\"2\"}}\n");
+        expected.put_slice(b"{\"bar\":\"create\"}\n");
+        expected.put_slice(b"{\"create\":{}}\n");
         expected.put_slice(b"{\"bar\":\"create\"}\n");
         expected.put_slice(b"{\"update\":{\"_id\":\"3\"}}\n");
         expected.put_slice(b"{\"baz\":\"update\"}\n");

--- a/opensearch/src/root/bulk.rs
+++ b/opensearch/src/root/bulk.rs
@@ -179,6 +179,11 @@ where
         BulkCreateOperation::new(id, source)
     }
 
+    /// Creates a new instance of [bulk create operation](BulkCreateOperation) without explicit id
+    pub fn create_no_id(source: B) -> BulkCreateOperation<B> {
+        BulkCreateOperation::new_no_id(source)
+    }
+
     /// Creates a new instance of a [bulk index operation](BulkIndexOperation)
     pub fn index(source: B) -> BulkIndexOperation<B> {
         BulkIndexOperation::new(source)
@@ -237,6 +242,22 @@ impl<B> BulkCreateOperation<B> {
                     action: BulkAction::Create,
                     metadata: BulkMetadata {
                         _id: Some(id.into()),
+                        ..Default::default()
+                    },
+                },
+                source: Some(source),
+            },
+        }
+    }
+
+    /// Creates a new instance of [BulkCreateOperation] without explicit id
+    pub fn new_no_id(source: B) -> Self {
+        Self {
+            operation: BulkOperation {
+                header: BulkHeader {
+                    action: BulkAction::Create,
+                    metadata: BulkMetadata {
+                        _id: None,
                         ..Default::default()
                     },
                 },
@@ -789,6 +810,7 @@ mod tests {
                 .routing("routing"),
         )?;
         ops.push(BulkOperation::create("2", CreateDoc { bar: "create" }))?;
+        ops.push(BulkOperation::create_no_id(CreateDoc { bar: "create" }))?;
         ops.push(BulkOperation::update("3", UpdateDoc { baz: "update" }))?;
         ops.push(BulkOperation::<()>::delete("4"))?;
 
@@ -799,6 +821,8 @@ mod tests {
         expected.put_slice(b"{\"index\":{\"_index\":\"index_doc\",\"_id\":\"1\",\"pipeline\":\"pipeline\",\"routing\":\"routing\"}}\n");
         expected.put_slice(b"{\"foo\":\"index\"}\n");
         expected.put_slice(b"{\"create\":{\"_id\":\"2\"}}\n");
+        expected.put_slice(b"{\"bar\":\"create\"}\n");
+        expected.put_slice(b"{\"create\":{}}\n");
         expected.put_slice(b"{\"bar\":\"create\"}\n");
         expected.put_slice(b"{\"update\":{\"_id\":\"3\"}}\n");
         expected.put_slice(b"{\"baz\":\"update\"}\n");

--- a/opensearch/tests/common/client.rs
+++ b/opensearch/tests/common/client.rs
@@ -151,8 +151,9 @@ pub async fn index_documents(client: &OpenSearch) -> Result<Response, Error> {
     if exists_response.status_code() == StatusCode::NOT_FOUND {
         let mut body: Vec<BulkOperation<_>> = vec![];
         for i in 1..=10 {
-            let op =
-                BulkOperation::index(Some(i.to_string()), json!({"title":"OpenSearch"})).into();
+            let op = BulkOperation::index(json!({"title":"OpenSearch"}))
+                .id(i.to_string())
+                .into();
             body.push(op);
         }
 

--- a/opensearch/tests/common/client.rs
+++ b/opensearch/tests/common/client.rs
@@ -151,9 +151,8 @@ pub async fn index_documents(client: &OpenSearch) -> Result<Response, Error> {
     if exists_response.status_code() == StatusCode::NOT_FOUND {
         let mut body: Vec<BulkOperation<_>> = vec![];
         for i in 1..=10 {
-            let op = BulkOperation::index(json!({"title":"OpenSearch"}))
-                .id(i.to_string())
-                .into();
+            let op =
+                BulkOperation::index(Some(i.to_string()), json!({"title":"OpenSearch"})).into();
             body.push(op);
         }
 


### PR DESCRIPTION

### Change (latest - revision 2)

Added new `create_no_id` and `new_no_id` constructors/helpers to support bulk create operations where no _id field is required.


#### Change (revision 1)

Changed types to `id: Option<S>` when `_id` is optional in the bulk request, otherwise, keep `id` parameter as `String`.

This change is making the Bulk operation constructor parameters more closely match the Bulk API, specifically when `_id` is required or not.


Summarized from the docs: https://www.elastic.co/guide/en/elasticsearch/reference/7.10/docs-bulk.html#bulk-api-request-body
- `create`: `_id` (optional, string)
- `delete`: `_id` (required, string)
- `index`: `_id` (optional, string)
- `update` `_id` (required, string)


### Issues Resolved

Related to, and may close issue #241 .

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
