### PR TITLE
[Backport 2.x] Add new bulk create constructor without optional _id field (#245)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 
 ### Added
+- Added new BulkCreate operation constructor without providing optional `id` field ([#245](https://github.com/opensearch-project/opensearch-rs/pull/245))
 
 ### Dependencies
 - Bumps `aws-*` dependencies to `1` ([#219](https://github.com/opensearch-project/opensearch-rs/pull/219))


### PR DESCRIPTION
### Description
Backports #245 from 28e3d47a54c4fe1ce0a3647c872411602dc6b1e2

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
