### PR TITLE
Switch to macos-13 runner for assemble github actions due to macos-latest is now arm64

### DIFF
--- a/.ci/functions/imports.sh
+++ b/.ci/functions/imports.sh
@@ -31,7 +31,7 @@ if [[ -z $opensearch_node_name ]]; then
   echo -e "\033[34;1mINFO:\033[0m Running opensearch $STACK_VERSION\033[0m"
 fi
 
-export script_path=$(dirname $(realpath -s $0))
+export script_path=$(dirname $(realpath $0))
 source $script_path/functions/cleanup.sh
 source $script_path/functions/wait-for-container.sh
 trap "cleanup_trap ${network_name}" EXIT

--- a/.ci/generate-certs.sh
+++ b/.ci/generate-certs.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-script_path=$(dirname $(realpath -s $0))
+script_path=$(dirname $(realpath $0))
 certs_dir="$script_path/certs"
 opensearch_dir="$script_path/opensearch"
 

--- a/.ci/run-opensearch.sh
+++ b/.ci/run-opensearch.sh
@@ -8,7 +8,7 @@
 # - Deleting the volume should not dependent on the container still running
 # - Fixed `ES_JAVA_OPTS` config
 
-script_path=$(dirname $(realpath -s $0))
+script_path=$(dirname $(realpath $0))
 source $script_path/functions/imports.sh
 set -euo pipefail
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-13]
         test-args:
           - "--features aws-auth"
           - "--no-default-features --features rustls-tls --package opensearch --test cert"


### PR DESCRIPTION
### Description
Switch to macos-13 runner for assemble github actions due to macos-latest is now arm64

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
