### PR TITLE
Switch codecov uploads to use OIDC as tokenless is no-longer supported

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '0 8 * * *'
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   test:
     name: Test
@@ -55,6 +59,7 @@ jobs:
         with:
           files: ./test_results/opensearch.lcov
           flags: unit
+          use_oidc: true
 
       - name: Save OpenSearch logs
         if: failure()
@@ -112,6 +117,7 @@ jobs:
         with:
           files: ./client/test_results/opensearch.lcov
           flags: integration
+          use_oidc: true
 
       - name: Save OpenSearch logs
         if: failure()
@@ -203,9 +209,11 @@ jobs:
           OPENSEARCH_PASSWORD: ${{ steps.opensearch.outputs.admin_password }}
 
       - uses: codecov/codecov-action@v4
+        if: github.event_name != 'schedule'
         with:
           files: ./client/test_results/opensearch.lcov
           flags: integration
+          use_oidc: true
 
       - name: Save OpenSearch logs
         if: failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,7 +141,7 @@ jobs:
       - name: GitHub App token
         id: github_app_token
         uses: tibdex/github-app-token@v1.5.0
-        if: github.event_name == 'schedule'
+        if: github.event_name == 'schedule' && github.repository == 'opensearch-project/opensearch-rs'
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -224,7 +224,7 @@ jobs:
             opensearch-*/logs/*
 
       - name: Create issue about failure
-        if: failure() && github.event_name == 'schedule'
+        if: failure() && github.event_name == 'schedule' && github.repository == 'opensearch-project/opensearch-rs'
         uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ steps.github_app_token.outputs.token }}


### PR DESCRIPTION
### Description
Switch codecov uploads to use OIDC as tokenless is no-longer supporte.
Also don't upload coverage on scheduled test runs as it skews results due to not running all tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
