### PR TITLE
[Backport 2.x] Update sysinfo requirement from 0.32.0 to 0.33.0 (#292)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 ### Dependencies
-- Bumps `sysinfo` from 0.31.2 to 0.32.0
+- Bumps `sysinfo` from 0.31.2 to 0.33.0
 
 ### Changed
 

--- a/opensearch/Cargo.toml
+++ b/opensearch/Cargo.toml
@@ -55,7 +55,7 @@ futures = "0.3.1"
 http-body-util = "0.1.0"
 hyper = { version = "1", features = ["full"] }
 hyper-util = { version = "0.1", features = ["full"] }
-sysinfo = "0.32.0"
+sysinfo = "0.33.0"
 test-case = "3"
 textwrap = "0.16"
 tokio = { version = "1", features = ["full"] }

--- a/opensearch/examples/cat_indices.rs
+++ b/opensearch/examples/cat_indices.rs
@@ -68,7 +68,7 @@ fn create_client() -> Result<OpenSearch, Error> {
     /// Determines if Fiddler.exe proxy process is running
     fn running_proxy() -> bool {
         let system = System::new_with_specifics(
-            RefreshKind::new().with_processes(ProcessRefreshKind::default()),
+            RefreshKind::nothing().with_processes(ProcessRefreshKind::default()),
         );
         let has_fiddler = system
             .processes_by_name(OsStr::new("Fiddler"))

--- a/opensearch/tests/common/client.rs
+++ b/opensearch/tests/common/client.rs
@@ -59,7 +59,7 @@ pub fn cluster_addr() -> String {
 /// Checks if Fiddler proxy process is running
 fn running_proxy() -> bool {
     let system = System::new_with_specifics(
-        RefreshKind::new().with_processes(ProcessRefreshKind::default()),
+        RefreshKind::nothing().with_processes(ProcessRefreshKind::default()),
     );
     let has_fiddler = system
         .processes_by_name(OsStr::new("Fiddler"))

--- a/yaml_test_runner/Cargo.toml
+++ b/yaml_test_runner/Cargo.toml
@@ -31,7 +31,7 @@ serde_yaml = "0.9"
 serde_json = { version = "1", features = ["arbitrary_precision"] }
 simple_logger = "5.0.0"
 syn = { version = "2.0", features = ["full"] }
-sysinfo = "0.32"
+sysinfo = "0.33"
 url = "2.1.1"
 tar = "0.4"
 flate2 = "1"


### PR DESCRIPTION
### Description
Backport #292 via 0f27696d62ebb4b6532d37e6ba9228f9dcdfd9b6

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
