### PR TITLE
change documentation field to homepage field in cargo.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump `itertools` from 0.13.0 to 0.14.0 ([#319](https://github.com/opensearch-project/opensearch-rs/pull/319))
 
 ### Changed
+- Changed documentation link in Cargo.toml to utilize standard docs.rs generation ([#000]())
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump `itertools` from 0.13.0 to 0.14.0 ([#319](https://github.com/opensearch-project/opensearch-rs/pull/319))
 
 ### Changed
-- Changed documentation link in Cargo.toml to utilize standard docs.rs generation ([#000]())
+- Changed documentation link in Cargo.toml to utilize standard docs.rs generation ([#323](https://github.com/opensearch-project/opensearch-rs/pull/323))
 
 ### Deprecated
 

--- a/opensearch/Cargo.toml
+++ b/opensearch/Cargo.toml
@@ -7,7 +7,7 @@ description = "Official OpenSearch Rust client"
 repository = "https://github.com/opensearch-project/opensearch-rs"
 keywords = ["opensearch", "elasticsearch", "search", "lucene"]
 categories = ["api-bindings", "database"]
-documentation = "https://opensearch.org/docs/latest"
+homepage = "https://opensearch.org/docs/latest"
 license = "Apache-2.0"
 readme = "../README.md"
 


### PR DESCRIPTION
### Description
Changes documentation field to homepage field in Cargo.toml utilizing docs.rs docs generation while still linking to Opensearch docs as homepage.

### Issues Resolved
Closes #255 .

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
