### PR TITLE
[Backport 2.x] Bump dangoslen/dependabot-changelog-helper from 3 to 4 (#329)

### DIFF
--- a/.github/workflows/dependabot_pr.yml
+++ b/.github/workflows/dependabot_pr.yml
@@ -29,7 +29,7 @@ jobs:
           token: ${{ steps.github_app_token.outputs.token }}
 
       - name: Update the changelog
-        uses: dangoslen/dependabot-changelog-helper@v3
+        uses: dangoslen/dependabot-changelog-helper@v4
         with:
           version: "Unreleased"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Dependencies
 - Bumps `sysinfo` from 0.31.2 to 0.33.0
-- Bump `dangoslen/dependabot-changelog-helper` from 2 to 3 ([#298](https://github.com/opensearch-project/opensearch-rs/pull/298))
+- Bump `dangoslen/dependabot-changelog-helper` from 2 to 4 ([#298](https://github.com/opensearch-project/opensearch-rs/pull/298), [#329](https://github.com/opensearch-project/opensearch-rs/pull/329))
 - Bump `VachaShah/backport` from 1.1.4 to 2.2.0 ([#299](https://github.com/opensearch-project/opensearch-rs/pull/299))
 - Bump `stefanzweifel/git-auto-commit-action` from 4 to 5 ([#300](https://github.com/opensearch-project/opensearch-rs/pull/300))
 - Bump `softprops/action-gh-release` from 1 to 2 ([#303](https://github.com/opensearch-project/opensearch-rs/pull/303))


### PR DESCRIPTION
### Description
Backport #329 via 5d16d03418fcc48fdc7d2962d03c6c9e2ecb63f3

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
