### PR TITLE
Specify head ref in dependabot PR workflow

### DIFF
--- a/.github/workflows/dependabot_pr.yml
+++ b/.github/workflows/dependabot_pr.yml
@@ -27,6 +27,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ steps.github_app_token.outputs.token }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Update the changelog
         uses: dangoslen/dependabot-changelog-helper@v4


### PR DESCRIPTION
### Description
Fixes failures in dependabot PR workflows. Mirrors https://github.com/opensearch-project/opensearch-java/pull/1653

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
