### PR TITLE
[Backport 2.x] Update sysinfo requirement from 0.35.0 to 0.36.0 (#346)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 ### Dependencies
-- Bumps `sysinfo` from 0.31.2 to 0.35.0 ([#331](https://github.com/opensearch-project/opensearch-rs/pull/331), [#339](https://github.com/opensearch-project/opensearch-rs/pull/339))
+- Bumps `sysinfo` from 0.31.2 to 0.36.0 ([#331](https://github.com/opensearch-project/opensearch-rs/pull/331), [#339](https://github.com/opensearch-project/opensearch-rs/pull/339), [#346](https://github.com/opensearch-project/opensearch-rs/pull/346))
 - Bump `dangoslen/dependabot-changelog-helper` from 2 to 4 ([#298](https://github.com/opensearch-project/opensearch-rs/pull/298), [#329](https://github.com/opensearch-project/opensearch-rs/pull/329))
 - Bump `VachaShah/backport` from 1.1.4 to 2.2.0 ([#299](https://github.com/opensearch-project/opensearch-rs/pull/299))
 - Bump `stefanzweifel/git-auto-commit-action` from 4 to 6 ([#300](https://github.com/opensearch-project/opensearch-rs/pull/300), [#343](https://github.com/opensearch-project/opensearch-rs/pull/343))

--- a/opensearch/Cargo.toml
+++ b/opensearch/Cargo.toml
@@ -55,7 +55,7 @@ futures = "0.3.1"
 http-body-util = "0.1.0"
 hyper = { version = "1", features = ["full"] }
 hyper-util = { version = "0.1", features = ["full"] }
-sysinfo = "0.35.0"
+sysinfo = "0.36.0"
 test-case = "3"
 textwrap = "0.16"
 tokio = { version = "1", features = ["full"] }

--- a/yaml_test_runner/Cargo.toml
+++ b/yaml_test_runner/Cargo.toml
@@ -31,7 +31,7 @@ serde_yaml = "0.9"
 serde_json = { version = "1", features = ["arbitrary_precision"] }
 simple_logger = "5.0.0"
 syn = { version = "2.0", features = ["full"] }
-sysinfo = "0.35"
+sysinfo = "0.36"
 url = "2.1.1"
 tar = "0.4"
 flate2 = "1"


### PR DESCRIPTION
(cherry picked from commit a3022ae9bdf47ee6b17dcd058fefb77dcb849a02)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
