### PR TITLE
Move dblock to emeritus maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# This list should match MAINTAINERS.md. 
-*   @dblock @Xtansia @VachaShah @reta
+# This list should match MAINTAINERS.md.
+*   @Xtansia @VachaShah @reta

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,15 +4,15 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer         | GitHub ID                                 | Affiliation |
-| ------------------ | ----------------------------------------- | ----------- |
-| Daniel Doubrovkine | [dblock](https://github.com/dblock)       | Independent |
-| Thomas Farr        | [Xtansia](https://github.com/Xtansia)     | Independent |
-| Vacha Shah         | [VachaShah](https://github.com/VachaShah) | Amazon      |
-| Andriy Redko       | [reta](https://github.com/reta)           | Independent |
+| Maintainer   | GitHub ID                                 | Affiliation |
+| ------------ | ----------------------------------------- | ----------- |
+| Thomas Farr  | [Xtansia](https://github.com/Xtansia)     | Independent |
+| Vacha Shah   | [VachaShah](https://github.com/VachaShah) | Amazon      |
+| Andriy Redko | [reta](https://github.com/reta)           | Independent |
 
 ## Emeritus
 
-| Maintainer    | GitHub ID                                     | Affiliation |
-| ------------- | --------------------------------------------- | ----------- |
-| Aditya Jindal | [adityaj1107](https://github.com/adityaj1107) | Amazon      |
+| Maintainer         | GitHub ID                                     | Affiliation |
+| ------------------ | --------------------------------------------- | ----------- |
+| Aditya Jindal      | [adityaj1107](https://github.com/adityaj1107) | Amazon      |
+| Daniel Doubrovkine | [dblock](https://github.com/dblock)           | Independent |


### PR DESCRIPTION
## Summary
- Moved dblock to emeritus maintainers section
- Removed dblock from CODEOWNERS

🤖 Generated with [Claude Code](https://claude.com/claude-code)