### PR TITLE
Use PUT method for Index API when custom document ID is provided

### DIFF
--- a/opensearch/src/root/mod.rs
+++ b/opensearch/src/root/mod.rs
@@ -4180,6 +4180,13 @@ pub enum IndexParts<'b> {
     Index(&'b str),
 }
 impl<'b> IndexParts<'b> {
+    #[doc = "Returns the HTTP method for this Index operation (PUT for custom ID, POST for auto-generated ID)"]
+    pub fn method(&self) -> Method {
+        match self {
+            IndexParts::IndexId(_, _) => Method::Put,
+            IndexParts::Index(_) => Method::Post,
+        }
+    }
     #[doc = "Builds a relative URL path to the Index API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -4383,8 +4390,8 @@ where
     }
     #[doc = "Creates an asynchronous call to the Index API that can be awaited"]
     pub async fn send(self) -> Result<Response, Error> {
+        let method = self.parts.method();
         let path = self.parts.url();
-        let method = Method::Post;
         let headers = self.headers;
         let timeout = self.request_timeout;
         let query_string = {


### PR DESCRIPTION
### Description
- Add method() function to IndexParts that returns PUT for IndexId, POST for Index
- Update send() to use dynamic method instead of hardcoded POST
- This fixes compatibility with OpenSearch Serverless SEARCH collections

This PR resolves the bug described in [issue 384](https://github.com/opensearch-project/opensearch-rs/issues/384)

### Issues Resolved
Closes [[Issue 384](https://github.com/opensearch-project/opensearch-rs/issues/384)]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
