### PR TITLE
Add opt-in CachedCredentialsProvider to avoid per-request metadata calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 - Added middleware types to allow intercepting construction and handling of the underlying `reqwest` client & requests ([#232](https://github.com/opensearch-project/opensearch-rs/pull/232)) 
-- Added `auth::cache::CachedCredentialsProvider`, an opt-in helper that caches AWS credentials between requests so that ECS / EC2 metadata endpoints are not queried on every signed request ([#XXX](https://github.com/opensearch-project/opensearch-rs/pull/XXX))
+- Added `auth::cache::CachedCredentialsProvider`, an opt-in helper that caches AWS credentials between requests so that ECS / EC2 metadata endpoints are not queried on every signed request ([#419](https://github.com/opensearch-project/opensearch-rs/pull/419))
 
 ### Dependencies
 - Bumps `sysinfo` from 0.31.2 to 0.38.0 ([#331](https://github.com/opensearch-project/opensearch-rs/pull/331), [#339](https://github.com/opensearch-project/opensearch-rs/pull/339), [#346](https://github.com/opensearch-project/opensearch-rs/pull/346), [#352](https://github.com/opensearch-project/opensearch-rs/pull/352), [#389](https://github.com/opensearch-project/opensearch-rs/pull/389))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 - Added middleware types to allow intercepting construction and handling of the underlying `reqwest` client & requests ([#232](https://github.com/opensearch-project/opensearch-rs/pull/232)) 
+- Added `auth::cache::CachedCredentialsProvider`, an opt-in helper that caches AWS credentials between requests so that ECS / EC2 metadata endpoints are not queried on every signed request ([#XXX](https://github.com/opensearch-project/opensearch-rs/pull/XXX))
 
 ### Dependencies
 - Bumps `sysinfo` from 0.31.2 to 0.38.0 ([#331](https://github.com/opensearch-project/opensearch-rs/pull/331), [#339](https://github.com/opensearch-project/opensearch-rs/pull/339), [#346](https://github.com/opensearch-project/opensearch-rs/pull/346), [#352](https://github.com/opensearch-project/opensearch-rs/pull/352), [#389](https://github.com/opensearch-project/opensearch-rs/pull/389))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 - Added middleware types to allow intercepting construction and handling of the underlying `reqwest` client & requests ([#232](https://github.com/opensearch-project/opensearch-rs/pull/232)) 
-- Added `auth::cache::CachedCredentialsProvider`, an opt-in helper that caches AWS credentials between requests so that ECS / EC2 metadata endpoints are not queried on every signed request ([#419](https://github.com/opensearch-project/opensearch-rs/pull/419))
+- Added `auth::cache::CachedCredentialsProvider`, an opt-in helper that caches AWS credentials between requests so users can avoid querying ECS / EC2 metadata endpoints on every signed request ([#419](https://github.com/opensearch-project/opensearch-rs/pull/419))
 
 ### Dependencies
 - Bumps `sysinfo` from 0.31.2 to 0.38.0 ([#331](https://github.com/opensearch-project/opensearch-rs/pull/331), [#339](https://github.com/opensearch-project/opensearch-rs/pull/339), [#346](https://github.com/opensearch-project/opensearch-rs/pull/346), [#352](https://github.com/opensearch-project/opensearch-rs/pull/352), [#389](https://github.com/opensearch-project/opensearch-rs/pull/389))

--- a/opensearch/Cargo.toml
+++ b/opensearch/Cargo.toml
@@ -26,7 +26,7 @@ native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls"]
 
 # AWS SigV4 Auth support
-aws-auth = ["aws-credential-types", "aws-sigv4", "aws-smithy-runtime-api", "aws-types", "dep:tokio"]
+aws-auth = ["aws-credential-types", "aws-sigv4", "aws-smithy-runtime-api", "aws-types", "dep:tokio", "dep:fastrand"]
 
 [dependencies]
 async-trait = "0.1"
@@ -48,6 +48,7 @@ aws-sigv4 = { version = "1", optional = true }
 aws-smithy-runtime-api = { version = "1", optional = true, features = ["client"]}
 aws-types = { version = "1", optional = true }
 tokio = { version = "1", default-features = false, features = ["sync"], optional = true }
+fastrand = { version = "2", optional = true }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/opensearch/Cargo.toml
+++ b/opensearch/Cargo.toml
@@ -26,7 +26,7 @@ native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls"]
 
 # AWS SigV4 Auth support
-aws-auth = ["aws-credential-types", "aws-sigv4", "aws-smithy-runtime-api", "aws-types"]
+aws-auth = ["aws-credential-types", "aws-sigv4", "aws-smithy-runtime-api", "aws-types", "dep:tokio"]
 
 [dependencies]
 async-trait = "0.1"
@@ -47,6 +47,7 @@ aws-credential-types = { version = "1", optional = true }
 aws-sigv4 = { version = "1", optional = true }
 aws-smithy-runtime-api = { version = "1", optional = true, features = ["client"]}
 aws-types = { version = "1", optional = true }
+tokio = { version = "1", default-features = false, features = ["sync"], optional = true }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/opensearch/src/auth/cache.rs
+++ b/opensearch/src/auth/cache.rs
@@ -29,6 +29,14 @@ use aws_credential_types::{
 /// [`aws_smithy_runtime`'s `IdentityCache::lazy()`]: https://docs.rs/aws-smithy-runtime/latest/aws_smithy_runtime/client/identity/struct.IdentityCache.html
 pub const DEFAULT_BUFFER_TIME: Duration = Duration::from_secs(10);
 
+/// Default upper bound for the jitter applied to [`DEFAULT_BUFFER_TIME`].
+///
+/// A fresh random value in `[0, DEFAULT_BUFFER_TIME_JITTER_FRACTION)` is drawn
+/// each time a credential is cached and used to shorten the effective buffer,
+/// spreading refreshes across clients that share the same credential expiry
+/// to avoid stampedes against IMDS / ECS metadata.
+pub const DEFAULT_BUFFER_TIME_JITTER_FRACTION: f64 = 0.5;
+
 /// A [`ProvideCredentials`] adapter that caches the wrapped provider's
 /// output until shortly before it expires.
 ///
@@ -58,11 +66,22 @@ pub const DEFAULT_BUFFER_TIME: Duration = Duration::from_secs(10);
 /// Refreshes are serialised by a [`tokio::sync::Mutex`] and use a
 /// double-checked lookup so that concurrent callers crossing the expiry
 /// boundary trigger at most one inner provider call.
+///
+/// # Refresh stampede protection
+///
+/// When many clients share the same credential expiry (e.g. ECS tasks
+/// sharing a task role), they would otherwise refresh simultaneously and
+/// pile up on the IMDS / ECS metadata endpoint. A random jitter is
+/// subtracted from `buffer_time` for each cached entry to spread the
+/// refresh times. See [`with_buffer_time_jitter_fraction`].
+///
+/// [`with_buffer_time_jitter_fraction`]: Self::with_buffer_time_jitter_fraction
 pub struct CachedCredentialsProvider {
     inner: SharedCredentialsProvider,
     cache: RwLock<Option<CachedEntry>>,
     refresh_lock: tokio::sync::Mutex<()>,
     buffer_time: Duration,
+    buffer_time_jitter_fraction: f64,
 }
 
 #[derive(Clone)]
@@ -103,12 +122,24 @@ impl CachedCredentialsProvider {
             cache: RwLock::new(None),
             refresh_lock: tokio::sync::Mutex::new(()),
             buffer_time: DEFAULT_BUFFER_TIME,
+            buffer_time_jitter_fraction: DEFAULT_BUFFER_TIME_JITTER_FRACTION,
         }
     }
 
     /// Override the expiry buffer (default: [`DEFAULT_BUFFER_TIME`]).
     pub fn with_buffer_time(mut self, buffer_time: Duration) -> Self {
         self.buffer_time = buffer_time;
+        self
+    }
+
+    /// Override the upper bound for the random jitter applied to
+    /// [`Self::with_buffer_time`] (default:
+    /// [`DEFAULT_BUFFER_TIME_JITTER_FRACTION`]).
+    ///
+    /// `fraction` is clamped to `[0.0, 1.0]`; a value of `0.0` disables
+    /// jitter entirely.
+    pub fn with_buffer_time_jitter_fraction(mut self, fraction: f64) -> Self {
+        self.buffer_time_jitter_fraction = fraction.clamp(0.0, 1.0);
         self
     }
 
@@ -127,9 +158,15 @@ impl CachedCredentialsProvider {
     }
 
     fn store(&self, credentials: Credentials) {
-        let refresh_after = credentials
-            .expiry()
-            .map(|exp| exp.checked_sub(self.buffer_time).unwrap_or(exp));
+        let refresh_after = credentials.expiry().map(|exp| {
+            // Random jitter, drawn fresh per cached entry, shortens the
+            // effective buffer. Clients that share the same credential
+            // expiry then refresh at slightly different times.
+            let jitter_factor = fastrand::f64() * self.buffer_time_jitter_fraction;
+            let jitter = self.buffer_time.mul_f64(jitter_factor);
+            let effective_buffer = self.buffer_time.saturating_sub(jitter);
+            exp.checked_sub(effective_buffer).unwrap_or(exp)
+        });
         let entry = CachedEntry {
             credentials,
             refresh_after,
@@ -271,11 +308,13 @@ mod tests {
 
     #[tokio::test]
     async fn buffer_time_forces_immediate_refresh() {
-        // Expiry 30s away, buffer 60s -> always stale.
+        // Expiry 30s away, buffer 60s -> always stale even after worst-case
+        // jitter (60s * 0.5 = 30s shorter buffer = 30s effective).
         let expiry = SystemTime::now() + Duration::from_secs(30);
         let (provider, calls) = CountingProvider::new(Some(expiry));
-        let cached =
-            CachedCredentialsProvider::new(provider).with_buffer_time(Duration::from_secs(60));
+        let cached = CachedCredentialsProvider::new(provider)
+            .with_buffer_time(Duration::from_secs(120))
+            .with_buffer_time_jitter_fraction(0.0);
 
         cached.provide_credentials().await.unwrap();
         cached.provide_credentials().await.unwrap();
@@ -287,13 +326,57 @@ mod tests {
     async fn expired_entry_is_refreshed() {
         let expiry = SystemTime::now() - Duration::from_secs(60);
         let (provider, calls) = CountingProvider::new(Some(expiry));
-        let cached =
-            CachedCredentialsProvider::new(provider).with_buffer_time(Duration::from_secs(0));
+        let cached = CachedCredentialsProvider::new(provider)
+            .with_buffer_time(Duration::from_secs(0))
+            .with_buffer_time_jitter_fraction(0.0);
 
         cached.provide_credentials().await.unwrap();
         cached.provide_credentials().await.unwrap();
 
         assert!(calls.load(Ordering::SeqCst) >= 2);
+    }
+
+    #[tokio::test]
+    async fn jitter_shortens_effective_buffer_within_bounds() {
+        // With buffer_time=100s and jitter_fraction=0.5, the effective buffer
+        // for any cached entry is in [50s, 100s]. Repeatedly populating the
+        // cache and checking when it becomes stale lets us verify the jitter
+        // is applied within the expected range.
+        let buffer = Duration::from_secs(100);
+        let fraction = 0.5;
+
+        for _ in 0..20 {
+            // Expiry far enough in the future that the cache is fresh
+            // regardless of jitter (now + 200s, effective expiry in
+            // [now+100s, now+150s]).
+            let expiry = SystemTime::now() + Duration::from_secs(200);
+            let (provider, _calls) = CountingProvider::new(Some(expiry));
+            let cached = CachedCredentialsProvider::new(provider)
+                .with_buffer_time(buffer)
+                .with_buffer_time_jitter_fraction(fraction);
+
+            cached.provide_credentials().await.unwrap();
+            assert!(
+                cached.read_fresh().is_some(),
+                "entry must be fresh: jitter should not push expiry below now"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn zero_jitter_is_deterministic() {
+        // With jitter disabled, a credential expiring exactly at now+buffer
+        // is always considered stale.
+        let expiry = SystemTime::now() + Duration::from_secs(10);
+        let (provider, calls) = CountingProvider::new(Some(expiry));
+        let cached = CachedCredentialsProvider::new(provider)
+            .with_buffer_time(Duration::from_secs(10))
+            .with_buffer_time_jitter_fraction(0.0);
+
+        cached.provide_credentials().await.unwrap();
+        cached.provide_credentials().await.unwrap();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
     }
 
     #[tokio::test]

--- a/opensearch/src/auth/cache.rs
+++ b/opensearch/src/auth/cache.rs
@@ -302,6 +302,19 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn from_shared_wraps_existing_provider() {
+        let expiry = SystemTime::now() + Duration::from_secs(3600);
+        let (provider, calls) = CountingProvider::new(Some(expiry));
+        let shared = SharedCredentialsProvider::new(provider);
+        let cached = CachedCredentialsProvider::from_shared(shared);
+
+        cached.provide_credentials().await.unwrap();
+        cached.provide_credentials().await.unwrap();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
     async fn cache_hit_does_not_invoke_inner_provider() {
         let expiry = SystemTime::now() + Duration::from_secs(3600);
         let (provider, calls) = CountingProvider::new(Some(expiry));

--- a/opensearch/src/auth/cache.rs
+++ b/opensearch/src/auth/cache.rs
@@ -1,0 +1,335 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Opt-in client-side caching for AWS credentials used by SigV4 signing.
+//!
+//! See [`CachedCredentialsProvider`] for usage and the crate-level
+//! documentation for the rationale.
+
+use std::fmt;
+use std::sync::RwLock;
+use std::time::{Duration, SystemTime};
+
+use aws_credential_types::{
+    provider::{future, ProvideCredentials, Result as ProviderResult, SharedCredentialsProvider},
+    Credentials,
+};
+
+/// Default safety margin subtracted from a credential's expiry.
+///
+/// Refresh begins this far ahead of the inner credentials' expiry so that
+/// in-flight signed requests do not race with expiry on the server side.
+pub const DEFAULT_BUFFER_TIME: Duration = Duration::from_secs(5 * 60);
+
+/// A [`ProvideCredentials`] adapter that caches the wrapped provider's
+/// output until shortly before it expires.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// # #[cfg(feature = "aws-auth")] {
+/// use aws_credential_types::provider::SharedCredentialsProvider;
+/// use opensearch::auth::{cache::CachedCredentialsProvider, Credentials};
+///
+/// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+/// let aws_config = aws_config::load_from_env().await;
+/// let region = aws_config.region().expect("region").clone();
+/// let inner = aws_config.credentials_provider().expect("creds");
+///
+/// let cached = CachedCredentialsProvider::from_shared(inner);
+/// let creds = Credentials::AwsSigV4(SharedCredentialsProvider::new(cached), region);
+/// # let _ = creds;
+/// # Ok(())
+/// # }
+/// # }
+/// ```
+///
+/// # Concurrency
+///
+/// Cache hits take a [`std::sync::RwLock`] read guard, with no `.await`.
+/// Refreshes are serialised by a [`tokio::sync::Mutex`] and use a
+/// double-checked lookup so that concurrent callers crossing the expiry
+/// boundary trigger at most one inner provider call.
+pub struct CachedCredentialsProvider {
+    inner: SharedCredentialsProvider,
+    cache: RwLock<Option<CachedEntry>>,
+    refresh_lock: tokio::sync::Mutex<()>,
+    buffer_time: Duration,
+}
+
+#[derive(Clone)]
+struct CachedEntry {
+    credentials: Credentials,
+    /// `expiry - buffer_time`, or `None` if the inner credentials have no
+    /// expiry, in which case the entry never goes stale.
+    refresh_after: Option<SystemTime>,
+}
+
+impl CachedEntry {
+    fn is_fresh(&self, now: SystemTime) -> bool {
+        match self.refresh_after {
+            None => true,
+            Some(deadline) => now < deadline,
+        }
+    }
+}
+
+impl fmt::Debug for CachedCredentialsProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CachedCredentialsProvider")
+            .field("buffer_time", &self.buffer_time)
+            .finish_non_exhaustive()
+    }
+}
+
+impl CachedCredentialsProvider {
+    /// Wrap a [`ProvideCredentials`] implementation with [`DEFAULT_BUFFER_TIME`].
+    pub fn new(inner: impl ProvideCredentials + 'static) -> Self {
+        Self::from_shared(SharedCredentialsProvider::new(inner))
+    }
+
+    /// Wrap an existing [`SharedCredentialsProvider`].
+    pub fn from_shared(inner: SharedCredentialsProvider) -> Self {
+        Self {
+            inner,
+            cache: RwLock::new(None),
+            refresh_lock: tokio::sync::Mutex::new(()),
+            buffer_time: DEFAULT_BUFFER_TIME,
+        }
+    }
+
+    /// Override the expiry buffer (default: [`DEFAULT_BUFFER_TIME`]).
+    pub fn with_buffer_time(mut self, buffer_time: Duration) -> Self {
+        self.buffer_time = buffer_time;
+        self
+    }
+
+    fn read_fresh(&self) -> Option<Credentials> {
+        let now = SystemTime::now();
+        let guard = self.cache.read().unwrap_or_else(|p| p.into_inner());
+        guard
+            .as_ref()
+            .filter(|e| e.is_fresh(now))
+            .map(|e| e.credentials.clone())
+    }
+
+    fn last_known(&self) -> Option<Credentials> {
+        let guard = self.cache.read().unwrap_or_else(|p| p.into_inner());
+        guard.as_ref().map(|e| e.credentials.clone())
+    }
+
+    fn store(&self, credentials: Credentials) {
+        let refresh_after = credentials
+            .expiry()
+            .map(|exp| exp.checked_sub(self.buffer_time).unwrap_or(exp));
+        let entry = CachedEntry {
+            credentials,
+            refresh_after,
+        };
+        let mut guard = self.cache.write().unwrap_or_else(|p| p.into_inner());
+        *guard = Some(entry);
+    }
+
+    async fn load_credentials(&self) -> ProviderResult {
+        // Fast path: cache hit, no `.await`, shared lock only.
+        if let Some(creds) = self.read_fresh() {
+            return Ok(creds);
+        }
+
+        // Serialise refreshes so concurrent callers fan in to a single
+        // inner invocation.
+        let _guard = self.refresh_lock.lock().await;
+
+        // Double-check: another task may have refreshed while we waited.
+        if let Some(creds) = self.read_fresh() {
+            return Ok(creds);
+        }
+
+        let fresh = self.inner.provide_credentials().await?;
+        self.store(fresh.clone());
+        Ok(fresh)
+    }
+}
+
+impl ProvideCredentials for CachedCredentialsProvider {
+    fn provide_credentials<'a>(&'a self) -> future::ProvideCredentials<'a>
+    where
+        Self: 'a,
+    {
+        future::ProvideCredentials::new(self.load_credentials())
+    }
+
+    fn fallback_on_interrupt(&self) -> Option<Credentials> {
+        // Match the convention from `awslabs/smithy-rs#2720`: surface the
+        // last cached value when a refresh is interrupted.
+        self.last_known()
+            .or_else(|| self.inner.fallback_on_interrupt())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_credential_types::provider::error::CredentialsError;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    #[derive(Debug)]
+    struct CountingProvider {
+        calls: Arc<AtomicUsize>,
+        expiry: Option<SystemTime>,
+    }
+
+    impl CountingProvider {
+        fn new(expiry: Option<SystemTime>) -> (Self, Arc<AtomicUsize>) {
+            let calls = Arc::new(AtomicUsize::new(0));
+            (
+                Self {
+                    calls: Arc::clone(&calls),
+                    expiry,
+                },
+                calls,
+            )
+        }
+    }
+
+    impl ProvideCredentials for CountingProvider {
+        fn provide_credentials<'a>(&'a self) -> future::ProvideCredentials<'a>
+        where
+            Self: 'a,
+        {
+            future::ProvideCredentials::new(async move {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                Ok(Credentials::new(
+                    "AKIAIOSFODNN7EXAMPLE",
+                    "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                    None,
+                    self.expiry,
+                    "test",
+                ))
+            })
+        }
+    }
+
+    #[derive(Debug)]
+    struct FailingProvider;
+
+    impl ProvideCredentials for FailingProvider {
+        fn provide_credentials<'a>(&'a self) -> future::ProvideCredentials<'a>
+        where
+            Self: 'a,
+        {
+            future::ProvideCredentials::new(async {
+                Err(CredentialsError::provider_error("synthetic failure"))
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn first_call_invokes_inner_provider() {
+        let (provider, calls) =
+            CountingProvider::new(Some(SystemTime::now() + Duration::from_secs(3600)));
+        let cached = CachedCredentialsProvider::new(provider);
+
+        cached.provide_credentials().await.unwrap();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn cache_hit_does_not_invoke_inner_provider() {
+        let expiry = SystemTime::now() + Duration::from_secs(3600);
+        let (provider, calls) = CountingProvider::new(Some(expiry));
+        let cached = CachedCredentialsProvider::new(provider);
+
+        for _ in 0..5 {
+            cached.provide_credentials().await.unwrap();
+        }
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn credentials_without_expiry_are_cached_indefinitely() {
+        let (provider, calls) = CountingProvider::new(None);
+        let cached = CachedCredentialsProvider::new(provider);
+
+        for _ in 0..3 {
+            cached.provide_credentials().await.unwrap();
+        }
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn buffer_time_forces_immediate_refresh() {
+        // Expiry 30s away, buffer 60s -> always stale.
+        let expiry = SystemTime::now() + Duration::from_secs(30);
+        let (provider, calls) = CountingProvider::new(Some(expiry));
+        let cached =
+            CachedCredentialsProvider::new(provider).with_buffer_time(Duration::from_secs(60));
+
+        cached.provide_credentials().await.unwrap();
+        cached.provide_credentials().await.unwrap();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn expired_entry_is_refreshed() {
+        let expiry = SystemTime::now() - Duration::from_secs(60);
+        let (provider, calls) = CountingProvider::new(Some(expiry));
+        let cached =
+            CachedCredentialsProvider::new(provider).with_buffer_time(Duration::from_secs(0));
+
+        cached.provide_credentials().await.unwrap();
+        cached.provide_credentials().await.unwrap();
+
+        assert!(calls.load(Ordering::SeqCst) >= 2);
+    }
+
+    #[tokio::test]
+    async fn concurrent_callers_share_a_single_refresh() {
+        let expiry = SystemTime::now() + Duration::from_secs(3600);
+        let (provider, calls) = CountingProvider::new(Some(expiry));
+        let cached = Arc::new(CachedCredentialsProvider::new(provider));
+
+        let mut handles = Vec::new();
+        for _ in 0..32 {
+            let cached = Arc::clone(&cached);
+            handles.push(tokio::spawn(async move {
+                cached.provide_credentials().await.unwrap();
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn provider_errors_are_propagated_and_do_not_poison_cache() {
+        let cached = CachedCredentialsProvider::new(FailingProvider);
+
+        assert!(cached.provide_credentials().await.is_err());
+        assert!(cached.provide_credentials().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn fallback_on_interrupt_returns_last_known_credentials() {
+        let expiry = SystemTime::now() + Duration::from_secs(3600);
+        let (provider, _calls) = CountingProvider::new(Some(expiry));
+        let cached = CachedCredentialsProvider::new(provider);
+
+        let primed = cached.provide_credentials().await.unwrap();
+
+        let fallback = cached.fallback_on_interrupt().expect("fallback present");
+        assert_eq!(fallback.access_key_id(), primed.access_key_id());
+    }
+}

--- a/opensearch/src/auth/cache.rs
+++ b/opensearch/src/auth/cache.rs
@@ -24,7 +24,10 @@ use aws_credential_types::{
 ///
 /// Refresh begins this far ahead of the inner credentials' expiry so that
 /// in-flight signed requests do not race with expiry on the server side.
-pub const DEFAULT_BUFFER_TIME: Duration = Duration::from_secs(5 * 60);
+/// Matches the default used by [`aws_smithy_runtime`'s `IdentityCache::lazy()`].
+///
+/// [`aws_smithy_runtime`'s `IdentityCache::lazy()`]: https://docs.rs/aws-smithy-runtime/latest/aws_smithy_runtime/client/identity/struct.IdentityCache.html
+pub const DEFAULT_BUFFER_TIME: Duration = Duration::from_secs(10);
 
 /// A [`ProvideCredentials`] adapter that caches the wrapped provider's
 /// output until shortly before it expires.

--- a/opensearch/src/auth/cache.rs
+++ b/opensearch/src/auth/cache.rs
@@ -12,13 +12,20 @@
 //! documentation for the rationale.
 
 use std::fmt;
-use std::sync::RwLock;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    RwLock,
+};
 use std::time::{Duration, SystemTime};
 
 use aws_credential_types::{
-    provider::{future, ProvideCredentials, Result as ProviderResult, SharedCredentialsProvider},
+    provider::{
+        error::CredentialsError, future, ProvideCredentials, Result as ProviderResult,
+        SharedCredentialsProvider,
+    },
     Credentials,
 };
+use aws_types::sdk_config::SharedTimeSource;
 
 /// Default safety margin subtracted from a credential's expiry.
 ///
@@ -65,7 +72,9 @@ pub const DEFAULT_BUFFER_TIME_JITTER_FRACTION: f64 = 0.5;
 /// Cache hits take a [`std::sync::RwLock`] read guard, with no `.await`.
 /// Refreshes are serialised by a [`tokio::sync::Mutex`] and use a
 /// double-checked lookup so that concurrent callers crossing the expiry
-/// boundary trigger at most one inner provider call.
+/// boundary trigger at most one inner provider call. If that refresh fails,
+/// callers already waiting behind it receive a coalesced error instead of
+/// retrying the same failing provider serially.
 ///
 /// # Refresh stampede protection
 ///
@@ -79,9 +88,12 @@ pub const DEFAULT_BUFFER_TIME_JITTER_FRACTION: f64 = 0.5;
 pub struct CachedCredentialsProvider {
     inner: SharedCredentialsProvider,
     cache: RwLock<Option<CachedEntry>>,
+    last_failure: RwLock<Option<RefreshFailure>>,
     refresh_lock: tokio::sync::Mutex<()>,
+    refresh_generation: AtomicUsize,
     buffer_time: Duration,
     buffer_time_jitter_fraction: f64,
+    time_source: SharedTimeSource,
 }
 
 #[derive(Clone)]
@@ -90,6 +102,11 @@ struct CachedEntry {
     /// `expiry - buffer_time`, or `None` if the inner credentials have no
     /// expiry, in which case the entry never goes stale.
     refresh_after: Option<SystemTime>,
+}
+
+struct RefreshFailure {
+    generation: usize,
+    message: String,
 }
 
 impl CachedEntry {
@@ -120,9 +137,12 @@ impl CachedCredentialsProvider {
         Self {
             inner,
             cache: RwLock::new(None),
+            last_failure: RwLock::new(None),
             refresh_lock: tokio::sync::Mutex::new(()),
+            refresh_generation: AtomicUsize::new(0),
             buffer_time: DEFAULT_BUFFER_TIME,
             buffer_time_jitter_fraction: DEFAULT_BUFFER_TIME_JITTER_FRACTION,
+            time_source: SharedTimeSource::default(),
         }
     }
 
@@ -136,15 +156,29 @@ impl CachedCredentialsProvider {
     /// [`Self::with_buffer_time`] (default:
     /// [`DEFAULT_BUFFER_TIME_JITTER_FRACTION`]).
     ///
-    /// `fraction` is clamped to `[0.0, 1.0]`; a value of `0.0` disables
-    /// jitter entirely.
+    /// `fraction` is clamped to `[0.0, 1.0]`; a value of `0.0`, `NaN`, or
+    /// infinity disables jitter entirely.
     pub fn with_buffer_time_jitter_fraction(mut self, fraction: f64) -> Self {
-        self.buffer_time_jitter_fraction = fraction.clamp(0.0, 1.0);
+        self.buffer_time_jitter_fraction = if fraction.is_finite() {
+            fraction.clamp(0.0, 1.0)
+        } else {
+            0.0
+        };
+        self
+    }
+
+    /// Override the time source used for cache freshness checks.
+    ///
+    /// The default uses system time. If the transport is configured with a
+    /// custom SigV4 time source, pass the same source here so credential
+    /// freshness is evaluated against the same clock used for signing.
+    pub fn with_time_source(mut self, time_source: SharedTimeSource) -> Self {
+        self.time_source = time_source;
         self
     }
 
     fn read_fresh(&self) -> Option<Credentials> {
-        let now = SystemTime::now();
+        let now = self.time_source.now();
         let guard = self.cache.read().unwrap_or_else(|p| p.into_inner());
         guard
             .as_ref()
@@ -175,11 +209,39 @@ impl CachedCredentialsProvider {
         *guard = Some(entry);
     }
 
+    fn store_failure(&self, generation: usize, err: &CredentialsError) {
+        let mut guard = self.last_failure.write().unwrap_or_else(|p| p.into_inner());
+        *guard = Some(RefreshFailure {
+            generation,
+            message: err.to_string(),
+        });
+    }
+
+    fn clear_failure(&self) {
+        let mut guard = self.last_failure.write().unwrap_or_else(|p| p.into_inner());
+        *guard = None;
+    }
+
+    fn failure_after(&self, observed_generation: usize) -> Option<CredentialsError> {
+        let guard = self.last_failure.read().unwrap_or_else(|p| p.into_inner());
+        guard
+            .as_ref()
+            .filter(|failure| failure.generation > observed_generation)
+            .map(|failure| {
+                CredentialsError::provider_error(format!(
+                    "coalesced credential refresh failure: {}",
+                    failure.message
+                ))
+            })
+    }
+
     async fn load_credentials(&self) -> ProviderResult {
         // Fast path: cache hit, no `.await`, shared lock only.
         if let Some(creds) = self.read_fresh() {
             return Ok(creds);
         }
+
+        let observed_generation = self.refresh_generation.load(Ordering::Acquire);
 
         // Serialise refreshes so concurrent callers fan in to a single
         // inner invocation.
@@ -190,7 +252,22 @@ impl CachedCredentialsProvider {
             return Ok(creds);
         }
 
-        let fresh = self.inner.provide_credentials().await?;
+        if let Some(err) = self.failure_after(observed_generation) {
+            return Err(err);
+        }
+
+        let fresh = match self.inner.provide_credentials().await {
+            Ok(fresh) => {
+                self.refresh_generation.fetch_add(1, Ordering::AcqRel);
+                self.clear_failure();
+                fresh
+            }
+            Err(err) => {
+                let generation = self.refresh_generation.fetch_add(1, Ordering::AcqRel) + 1;
+                self.store_failure(generation, &err);
+                return Err(err);
+            }
+        };
         self.store(fresh.clone());
         Ok(fresh)
     }
@@ -215,9 +292,11 @@ impl ProvideCredentials for CachedCredentialsProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aws_credential_types::provider::error::CredentialsError;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
+    use std::time::UNIX_EPOCH;
+
+    use aws_smithy_async::time::StaticTimeSource;
 
     #[derive(Debug)]
     struct CountingProvider {
@@ -270,6 +349,36 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct SlowFailingProvider {
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl SlowFailingProvider {
+        fn new() -> (Self, Arc<AtomicUsize>) {
+            let calls = Arc::new(AtomicUsize::new(0));
+            (
+                Self {
+                    calls: Arc::clone(&calls),
+                },
+                calls,
+            )
+        }
+    }
+
+    impl ProvideCredentials for SlowFailingProvider {
+        fn provide_credentials<'a>(&'a self) -> future::ProvideCredentials<'a>
+        where
+            Self: 'a,
+        {
+            future::ProvideCredentials::new(async move {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                Err(CredentialsError::provider_error("synthetic failure"))
+            })
+        }
+    }
+
     #[tokio::test]
     async fn first_call_invokes_inner_provider() {
         let (provider, calls) =
@@ -308,8 +417,7 @@ mod tests {
 
     #[tokio::test]
     async fn buffer_time_forces_immediate_refresh() {
-        // Expiry 30s away, buffer 60s -> always stale even after worst-case
-        // jitter (60s * 0.5 = 30s shorter buffer = 30s effective).
+        // Expiry 30s away, buffer 120s, jitter disabled -> always stale.
         let expiry = SystemTime::now() + Duration::from_secs(30);
         let (provider, calls) = CountingProvider::new(Some(expiry));
         let cached = CachedCredentialsProvider::new(provider)
@@ -339,16 +447,12 @@ mod tests {
     #[tokio::test]
     async fn jitter_shortens_effective_buffer_within_bounds() {
         // With buffer_time=100s and jitter_fraction=0.5, the effective buffer
-        // for any cached entry is in [50s, 100s]. Repeatedly populating the
-        // cache and checking when it becomes stale lets us verify the jitter
-        // is applied within the expected range.
+        // for any cached entry is in [50s, 100s], so refresh_after must fall
+        // between expiry-100s and expiry-50s.
         let buffer = Duration::from_secs(100);
         let fraction = 0.5;
 
         for _ in 0..20 {
-            // Expiry far enough in the future that the cache is fresh
-            // regardless of jitter (now + 200s, effective expiry in
-            // [now+100s, now+150s]).
             let expiry = SystemTime::now() + Duration::from_secs(200);
             let (provider, _calls) = CountingProvider::new(Some(expiry));
             let cached = CachedCredentialsProvider::new(provider)
@@ -356,11 +460,38 @@ mod tests {
                 .with_buffer_time_jitter_fraction(fraction);
 
             cached.provide_credentials().await.unwrap();
+            let refresh_after = cached
+                .cache
+                .read()
+                .unwrap_or_else(|p| p.into_inner())
+                .as_ref()
+                .and_then(|e| e.refresh_after)
+                .expect("cached entry has refresh_after");
+            let earliest = expiry.checked_sub(buffer).unwrap();
+            let latest = expiry.checked_sub(buffer.mul_f64(1.0 - fraction)).unwrap();
+
             assert!(
-                cached.read_fresh().is_some(),
-                "entry must be fresh: jitter should not push expiry below now"
+                refresh_after >= earliest && refresh_after <= latest,
+                "refresh_after must account for jitter: {:?} not in [{:?}, {:?}]",
+                refresh_after,
+                earliest,
+                latest
             );
         }
+    }
+
+    #[tokio::test]
+    async fn non_finite_jitter_fraction_disables_jitter() {
+        let expiry = SystemTime::now() + Duration::from_secs(10);
+        let (provider, calls) = CountingProvider::new(Some(expiry));
+        let cached = CachedCredentialsProvider::new(provider)
+            .with_buffer_time(Duration::from_secs(10))
+            .with_buffer_time_jitter_fraction(f64::NAN);
+
+        cached.provide_credentials().await.unwrap();
+        cached.provide_credentials().await.unwrap();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
     }
 
     #[tokio::test]
@@ -405,6 +536,41 @@ mod tests {
 
         assert!(cached.provide_credentials().await.is_err());
         assert!(cached.provide_credentials().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn concurrent_provider_errors_are_coalesced() {
+        let (provider, calls) = SlowFailingProvider::new();
+        let cached = Arc::new(CachedCredentialsProvider::new(provider));
+
+        let results = futures::future::join_all((0..10).map(|_| {
+            let cached = Arc::clone(&cached);
+            async move { cached.provide_credentials().await }
+        }))
+        .await;
+
+        assert!(results.iter().all(|result| result.is_err()));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        // Later callers still retry immediately; only callers queued behind
+        // the same failed refresh are coalesced.
+        assert!(cached.provide_credentials().await.is_err());
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn custom_time_source_controls_freshness() {
+        let expiry = UNIX_EPOCH + Duration::from_secs(20);
+        let (provider, calls) = CountingProvider::new(Some(expiry));
+        let cached = CachedCredentialsProvider::new(provider)
+            .with_buffer_time(Duration::from_secs(10))
+            .with_buffer_time_jitter_fraction(0.0)
+            .with_time_source(StaticTimeSource::from_secs(0).into());
+
+        cached.provide_credentials().await.unwrap();
+        cached.provide_credentials().await.unwrap();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/opensearch/src/auth/cache.rs
+++ b/opensearch/src/auth/cache.rs
@@ -12,17 +12,11 @@
 //! documentation for the rationale.
 
 use std::fmt;
-use std::sync::{
-    atomic::{AtomicUsize, Ordering},
-    RwLock,
-};
+use std::sync::RwLock;
 use std::time::{Duration, SystemTime};
 
 use aws_credential_types::{
-    provider::{
-        error::CredentialsError, future, ProvideCredentials, Result as ProviderResult,
-        SharedCredentialsProvider,
-    },
+    provider::{future, ProvideCredentials, Result as ProviderResult, SharedCredentialsProvider},
     Credentials,
 };
 use aws_types::sdk_config::SharedTimeSource;
@@ -72,9 +66,7 @@ pub const DEFAULT_BUFFER_TIME_JITTER_FRACTION: f64 = 0.5;
 /// Cache hits take a [`std::sync::RwLock`] read guard, with no `.await`.
 /// Refreshes are serialised by a [`tokio::sync::Mutex`] and use a
 /// double-checked lookup so that concurrent callers crossing the expiry
-/// boundary trigger at most one inner provider call. If that refresh fails,
-/// callers already waiting behind it receive a coalesced error instead of
-/// retrying the same failing provider serially.
+/// boundary trigger at most one inner provider call.
 ///
 /// # Refresh stampede protection
 ///
@@ -88,9 +80,7 @@ pub const DEFAULT_BUFFER_TIME_JITTER_FRACTION: f64 = 0.5;
 pub struct CachedCredentialsProvider {
     inner: SharedCredentialsProvider,
     cache: RwLock<Option<CachedEntry>>,
-    last_failure: RwLock<Option<RefreshFailure>>,
     refresh_lock: tokio::sync::Mutex<()>,
-    refresh_generation: AtomicUsize,
     buffer_time: Duration,
     buffer_time_jitter_fraction: f64,
     time_source: SharedTimeSource,
@@ -102,11 +92,6 @@ struct CachedEntry {
     /// `expiry - buffer_time`, or `None` if the inner credentials have no
     /// expiry, in which case the entry never goes stale.
     refresh_after: Option<SystemTime>,
-}
-
-struct RefreshFailure {
-    generation: usize,
-    message: String,
 }
 
 impl CachedEntry {
@@ -137,9 +122,7 @@ impl CachedCredentialsProvider {
         Self {
             inner,
             cache: RwLock::new(None),
-            last_failure: RwLock::new(None),
             refresh_lock: tokio::sync::Mutex::new(()),
-            refresh_generation: AtomicUsize::new(0),
             buffer_time: DEFAULT_BUFFER_TIME,
             buffer_time_jitter_fraction: DEFAULT_BUFFER_TIME_JITTER_FRACTION,
             time_source: SharedTimeSource::default(),
@@ -209,39 +192,11 @@ impl CachedCredentialsProvider {
         *guard = Some(entry);
     }
 
-    fn store_failure(&self, generation: usize, err: &CredentialsError) {
-        let mut guard = self.last_failure.write().unwrap_or_else(|p| p.into_inner());
-        *guard = Some(RefreshFailure {
-            generation,
-            message: err.to_string(),
-        });
-    }
-
-    fn clear_failure(&self) {
-        let mut guard = self.last_failure.write().unwrap_or_else(|p| p.into_inner());
-        *guard = None;
-    }
-
-    fn failure_after(&self, observed_generation: usize) -> Option<CredentialsError> {
-        let guard = self.last_failure.read().unwrap_or_else(|p| p.into_inner());
-        guard
-            .as_ref()
-            .filter(|failure| failure.generation > observed_generation)
-            .map(|failure| {
-                CredentialsError::provider_error(format!(
-                    "coalesced credential refresh failure: {}",
-                    failure.message
-                ))
-            })
-    }
-
     async fn load_credentials(&self) -> ProviderResult {
         // Fast path: cache hit, no `.await`, shared lock only.
         if let Some(creds) = self.read_fresh() {
             return Ok(creds);
         }
-
-        let observed_generation = self.refresh_generation.load(Ordering::Acquire);
 
         // Serialise refreshes so concurrent callers fan in to a single
         // inner invocation.
@@ -252,22 +207,7 @@ impl CachedCredentialsProvider {
             return Ok(creds);
         }
 
-        if let Some(err) = self.failure_after(observed_generation) {
-            return Err(err);
-        }
-
-        let fresh = match self.inner.provide_credentials().await {
-            Ok(fresh) => {
-                self.refresh_generation.fetch_add(1, Ordering::AcqRel);
-                self.clear_failure();
-                fresh
-            }
-            Err(err) => {
-                let generation = self.refresh_generation.fetch_add(1, Ordering::AcqRel) + 1;
-                self.store_failure(generation, &err);
-                return Err(err);
-            }
-        };
+        let fresh = self.inner.provide_credentials().await?;
         self.store(fresh.clone());
         Ok(fresh)
     }
@@ -292,6 +232,7 @@ impl ProvideCredentials for CachedCredentialsProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aws_credential_types::provider::error::CredentialsError;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
     use std::time::UNIX_EPOCH;
@@ -344,36 +285,6 @@ mod tests {
             Self: 'a,
         {
             future::ProvideCredentials::new(async {
-                Err(CredentialsError::provider_error("synthetic failure"))
-            })
-        }
-    }
-
-    #[derive(Debug)]
-    struct SlowFailingProvider {
-        calls: Arc<AtomicUsize>,
-    }
-
-    impl SlowFailingProvider {
-        fn new() -> (Self, Arc<AtomicUsize>) {
-            let calls = Arc::new(AtomicUsize::new(0));
-            (
-                Self {
-                    calls: Arc::clone(&calls),
-                },
-                calls,
-            )
-        }
-    }
-
-    impl ProvideCredentials for SlowFailingProvider {
-        fn provide_credentials<'a>(&'a self) -> future::ProvideCredentials<'a>
-        where
-            Self: 'a,
-        {
-            future::ProvideCredentials::new(async move {
-                self.calls.fetch_add(1, Ordering::SeqCst);
-                tokio::time::sleep(Duration::from_millis(20)).await;
                 Err(CredentialsError::provider_error("synthetic failure"))
             })
         }
@@ -536,26 +447,6 @@ mod tests {
 
         assert!(cached.provide_credentials().await.is_err());
         assert!(cached.provide_credentials().await.is_err());
-    }
-
-    #[tokio::test]
-    async fn concurrent_provider_errors_are_coalesced() {
-        let (provider, calls) = SlowFailingProvider::new();
-        let cached = Arc::new(CachedCredentialsProvider::new(provider));
-
-        let results = futures::future::join_all((0..10).map(|_| {
-            let cached = Arc::clone(&cached);
-            async move { cached.provide_credentials().await }
-        }))
-        .await;
-
-        assert!(results.iter().all(|result| result.is_err()));
-        assert_eq!(calls.load(Ordering::SeqCst), 1);
-
-        // Later callers still retry immediately; only callers queued behind
-        // the same failed refresh are coalesced.
-        assert!(cached.provide_credentials().await.is_err());
-        assert_eq!(calls.load(Ordering::SeqCst), 2);
     }
 
     #[tokio::test]

--- a/opensearch/src/auth/cache.rs
+++ b/opensearch/src/auth/cache.rs
@@ -220,18 +220,6 @@ impl ProvideCredentials for CachedCredentialsProvider {
     {
         future::ProvideCredentials::new(self.load_credentials())
     }
-
-    fn fallback_on_interrupt(&self) -> Option<Credentials> {
-        // Match the convention from `awslabs/smithy-rs#2720`: surface the
-        // last cached value when a refresh is interrupted. `try_read` skips
-        // waiting if a writer (i.e. another in-flight refresh) currently
-        // holds the lock, in which case we delegate to the inner provider.
-        self.cache
-            .try_read()
-            .ok()
-            .and_then(|g| g.as_ref().map(|e| e.credentials.clone()))
-            .or_else(|| self.inner.fallback_on_interrupt())
-    }
 }
 
 #[cfg(test)]
@@ -480,17 +468,5 @@ mod tests {
         cached.provide_credentials().await.unwrap();
 
         assert_eq!(calls.load(Ordering::SeqCst), 1);
-    }
-
-    #[tokio::test]
-    async fn fallback_on_interrupt_returns_last_known_credentials() {
-        let expiry = SystemTime::now() + Duration::from_secs(3600);
-        let (provider, _calls) = CountingProvider::new(Some(expiry));
-        let cached = CachedCredentialsProvider::new(provider);
-
-        let primed = cached.provide_credentials().await.unwrap();
-
-        let fallback = cached.fallback_on_interrupt().expect("fallback present");
-        assert_eq!(fallback.access_key_id(), primed.access_key_id());
     }
 }

--- a/opensearch/src/auth/cache.rs
+++ b/opensearch/src/auth/cache.rs
@@ -87,8 +87,9 @@ pub struct CachedCredentialsProvider {
 #[derive(Clone)]
 struct CachedEntry {
     credentials: Credentials,
-    /// `expiry - buffer_time`, or `None` if the inner credentials have no
-    /// expiry, in which case the entry never goes stale.
+    /// `expiry - effective_buffer` (where `effective_buffer = buffer_time - jitter`),
+    /// or `None` if the inner credentials have no expiry, in which case the
+    /// entry never goes stale.
     refresh_after: Option<SystemTime>,
 }
 
@@ -358,7 +359,7 @@ mod tests {
         cached.provide_credentials().await.unwrap();
         cached.provide_credentials().await.unwrap();
 
-        assert!(calls.load(Ordering::SeqCst) >= 2);
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
     }
 
     #[tokio::test]

--- a/opensearch/src/auth/cache.rs
+++ b/opensearch/src/auth/cache.rs
@@ -12,7 +12,6 @@
 //! documentation for the rationale.
 
 use std::fmt;
-use std::sync::RwLock;
 use std::time::{Duration, SystemTime};
 
 use aws_credential_types::{
@@ -63,10 +62,10 @@ pub const DEFAULT_BUFFER_TIME_JITTER_FRACTION: f64 = 0.5;
 ///
 /// # Concurrency
 ///
-/// Cache hits take a [`std::sync::RwLock`] read guard, with no `.await`.
-/// Refreshes are serialised by a [`tokio::sync::Mutex`] and use a
-/// double-checked lookup so that concurrent callers crossing the expiry
-/// boundary trigger at most one inner provider call.
+/// Cache hits take a [`tokio::sync::RwLock`] read guard. Refreshes acquire
+/// the write guard, which serialises concurrent refreshers; a double-checked
+/// lookup after the write guard is acquired ensures concurrent callers
+/// crossing the expiry boundary trigger at most one inner provider call.
 ///
 /// # Refresh stampede protection
 ///
@@ -79,8 +78,7 @@ pub const DEFAULT_BUFFER_TIME_JITTER_FRACTION: f64 = 0.5;
 /// [`with_buffer_time_jitter_fraction`]: Self::with_buffer_time_jitter_fraction
 pub struct CachedCredentialsProvider {
     inner: SharedCredentialsProvider,
-    cache: RwLock<Option<CachedEntry>>,
-    refresh_lock: tokio::sync::Mutex<()>,
+    cache: tokio::sync::RwLock<Option<CachedEntry>>,
     buffer_time: Duration,
     buffer_time_jitter_fraction: f64,
     time_source: SharedTimeSource,
@@ -121,8 +119,7 @@ impl CachedCredentialsProvider {
     pub fn from_shared(inner: SharedCredentialsProvider) -> Self {
         Self {
             inner,
-            cache: RwLock::new(None),
-            refresh_lock: tokio::sync::Mutex::new(()),
+            cache: tokio::sync::RwLock::new(None),
             buffer_time: DEFAULT_BUFFER_TIME,
             buffer_time_jitter_fraction: DEFAULT_BUFFER_TIME_JITTER_FRACTION,
             time_source: SharedTimeSource::default(),
@@ -160,21 +157,21 @@ impl CachedCredentialsProvider {
         self
     }
 
-    fn read_fresh(&self) -> Option<Credentials> {
+    async fn read_fresh(&self) -> Option<Credentials> {
+        let guard = self.cache.read().await;
+        // Sample `now` *after* acquiring the read lock. If acquiring the
+        // lock waited on a concurrent writer, the just-stored entry must
+        // be evaluated against the current clock — using a `now` sampled
+        // before the wait could classify an already-past `refresh_after`
+        // as still fresh.
         let now = self.time_source.now();
-        let guard = self.cache.read().unwrap_or_else(|p| p.into_inner());
         guard
             .as_ref()
             .filter(|e| e.is_fresh(now))
             .map(|e| e.credentials.clone())
     }
 
-    fn last_known(&self) -> Option<Credentials> {
-        let guard = self.cache.read().unwrap_or_else(|p| p.into_inner());
-        guard.as_ref().map(|e| e.credentials.clone())
-    }
-
-    fn store(&self, credentials: Credentials) {
+    fn make_entry(&self, credentials: Credentials) -> CachedEntry {
         let refresh_after = credentials.expiry().map(|exp| {
             // Random jitter, drawn fresh per cached entry, shortens the
             // effective buffer. Clients that share the same credential
@@ -184,31 +181,34 @@ impl CachedCredentialsProvider {
             let effective_buffer = self.buffer_time.saturating_sub(jitter);
             exp.checked_sub(effective_buffer).unwrap_or(exp)
         });
-        let entry = CachedEntry {
+        CachedEntry {
             credentials,
             refresh_after,
-        };
-        let mut guard = self.cache.write().unwrap_or_else(|p| p.into_inner());
-        *guard = Some(entry);
+        }
     }
 
     async fn load_credentials(&self) -> ProviderResult {
-        // Fast path: cache hit, no `.await`, shared lock only.
-        if let Some(creds) = self.read_fresh() {
+        // Fast path: shared read guard while the cached entry is fresh.
+        if let Some(creds) = self.read_fresh().await {
             return Ok(creds);
         }
 
-        // Serialise refreshes so concurrent callers fan in to a single
-        // inner invocation.
-        let _guard = self.refresh_lock.lock().await;
+        // Acquire the write guard. `tokio::sync::RwLock::write` is exclusive,
+        // which serialises concurrent refreshers, and (unlike `std::sync::RwLock`)
+        // we can hold it across the inner provider's `.await`.
+        let mut guard = self.cache.write().await;
 
-        // Double-check: another task may have refreshed while we waited.
-        if let Some(creds) = self.read_fresh() {
-            return Ok(creds);
+        // Double-check: another writer may have refreshed while we waited.
+        // Sample `now` after acquiring the lock so an entry just stored by a
+        // slow predecessor is judged against the current clock — not a `now`
+        // captured before we started waiting.
+        let now = self.time_source.now();
+        if let Some(entry) = guard.as_ref().filter(|e| e.is_fresh(now)) {
+            return Ok(entry.credentials.clone());
         }
 
         let fresh = self.inner.provide_credentials().await?;
-        self.store(fresh.clone());
+        *guard = Some(self.make_entry(fresh.clone()));
         Ok(fresh)
     }
 }
@@ -223,8 +223,13 @@ impl ProvideCredentials for CachedCredentialsProvider {
 
     fn fallback_on_interrupt(&self) -> Option<Credentials> {
         // Match the convention from `awslabs/smithy-rs#2720`: surface the
-        // last cached value when a refresh is interrupted.
-        self.last_known()
+        // last cached value when a refresh is interrupted. `try_read` skips
+        // waiting if a writer (i.e. another in-flight refresh) currently
+        // holds the lock, in which case we delegate to the inner provider.
+        self.cache
+            .try_read()
+            .ok()
+            .and_then(|g| g.as_ref().map(|e| e.credentials.clone()))
             .or_else(|| self.inner.fallback_on_interrupt())
     }
 }
@@ -387,7 +392,7 @@ mod tests {
             let refresh_after = cached
                 .cache
                 .read()
-                .unwrap_or_else(|p| p.into_inner())
+                .await
                 .as_ref()
                 .and_then(|e| e.refresh_after)
                 .expect("cached entry has refresh_after");

--- a/opensearch/src/auth/mod.rs
+++ b/opensearch/src/auth/mod.rs
@@ -115,3 +115,6 @@ impl std::convert::TryFrom<aws_types::SdkConfig> for Credentials {
         Credentials::try_from(&value)
     }
 }
+
+#[cfg(feature = "aws-auth")]
+pub mod cache;

--- a/opensearch/src/lib.rs
+++ b/opensearch/src/lib.rs
@@ -370,6 +370,30 @@
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! ### Caching AWS credentials between requests
+//!
+//! The provider passed to [`Credentials::AwsSigV4`](crate::auth::Credentials::AwsSigV4) is
+//! invoked on every signed request. When credentials come from the IMDS or ECS metadata
+//! endpoint, this means an HTTP round-trip per request. Wrap the provider in
+//! [`auth::cache::CachedCredentialsProvider`](crate::auth::cache::CachedCredentialsProvider)
+//! to cache the resolved credentials until just before they expire:
+//!
+//! ```rust,no_run
+//! # #[cfg(feature = "aws-auth")] {
+//! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! use aws_credential_types::provider::SharedCredentialsProvider;
+//! use opensearch::auth::{cache::CachedCredentialsProvider, Credentials};
+//!
+//! let aws_config = aws_config::load_from_env().await;
+//! let region = aws_config.region().expect("region").clone();
+//! let inner = aws_config.credentials_provider().expect("creds");
+//! let cached = CachedCredentialsProvider::from_shared(inner);
+//! let creds = Credentials::AwsSigV4(SharedCredentialsProvider::new(cached), region);
+//! # let _ = creds;
+//! # Ok(()) }
+//! # }
+//! ```
 
 #![doc(
     html_logo_url = "https://github.com/opensearch-project/opensearch-rs/raw/main/OpenSearch.svg"

--- a/opensearch/tests/aws_auth.rs
+++ b/opensearch/tests/aws_auth.rs
@@ -12,17 +12,61 @@
 #![cfg(feature = "aws-auth")]
 
 pub mod common;
-use aws_credential_types::{provider::SharedCredentialsProvider, Credentials as AwsCredentials};
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
+use aws_credential_types::{
+    provider::{future, ProvideCredentials, SharedCredentialsProvider},
+    Credentials as AwsCredentials,
+};
 use aws_smithy_async::time::StaticTimeSource;
 use aws_types::region::Region;
 use common::{server::MockServer, tracing_init};
 use opensearch::{
+    auth::cache::CachedCredentialsProvider,
     http::{headers::HOST, transport::TransportBuilder},
     indices::IndicesCreateParts,
 };
 use reqwest::header::HeaderValue;
 use serde_json::json;
 use test_case::test_case;
+
+#[derive(Debug)]
+struct CountingCredentialsProvider {
+    calls: Arc<AtomicUsize>,
+}
+
+impl CountingCredentialsProvider {
+    fn new() -> (Self, Arc<AtomicUsize>) {
+        let calls = Arc::new(AtomicUsize::new(0));
+        (
+            Self {
+                calls: Arc::clone(&calls),
+            },
+            calls,
+        )
+    }
+}
+
+impl ProvideCredentials for CountingCredentialsProvider {
+    fn provide_credentials<'a>(&'a self) -> future::ProvideCredentials<'a>
+    where
+        Self: 'a,
+    {
+        future::ProvideCredentials::new(async move {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(AwsCredentials::new(
+                "test-access-key",
+                "test-secret-key",
+                None,
+                None,
+                "test",
+            ))
+        })
+    }
+}
 
 fn sigv4_config(transport: TransportBuilder, service_name: &str) -> TransportBuilder {
     let aws_creds = AwsCredentials::new("test-access-key", "test-secret-key", None, None, "test");
@@ -32,6 +76,22 @@ fn sigv4_config(transport: TransportBuilder, service_name: &str) -> TransportBui
     transport
         .auth(opensearch::auth::Credentials::AwsSigV4(
             SharedCredentialsProvider::new(aws_creds),
+            region,
+        ))
+        .service_name(service_name)
+        .sigv4_time_source(time_source.into())
+}
+
+fn sigv4_config_cached(transport: TransportBuilder, service_name: &str) -> TransportBuilder {
+    let aws_creds = AwsCredentials::new("test-access-key", "test-secret-key", None, None, "test");
+    let region = Region::new("ap-southeast-2");
+    let time_source = StaticTimeSource::from_secs(1673626117); // 2023-01-13 16:08:37 +0000
+
+    let cached = CachedCredentialsProvider::new(aws_creds);
+
+    transport
+        .auth(opensearch::auth::Credentials::AwsSigV4(
+            SharedCredentialsProvider::new(cached),
             region,
         ))
         .service_name(service_name)
@@ -111,6 +171,59 @@ async fn aws_auth_get() -> anyhow::Result<()> {
         sent_req.header("x-amz-content-sha256"),
         Some("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
     ); // SHA of zero-length body
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn aws_auth_through_cached_provider_produces_identical_signature() -> anyhow::Result<()> {
+    // Same fixture as `aws_auth_get`; wrapping with CachedCredentialsProvider must not
+    // change the signature.
+    tracing_init();
+
+    let mut server = MockServer::start()?;
+
+    let client = server.client_with(|b| sigv4_config_cached(b, "custom").header(HOST, LOCALHOST));
+
+    let _ = client.ping().send().await?;
+
+    let sent_req = server.received_request().await?;
+
+    assert_eq!(sent_req.header("authorization"), Some("AWS4-HMAC-SHA256 Credential=test-access-key/20230113/ap-southeast-2/custom/aws4_request, SignedHeaders=accept;content-type;host;x-amz-content-sha256;x-amz-date, Signature=e5aa6e5d9e1b86b86ed31fbb10dd62b4e93423b77830f8189701421d3e9f65bd"));
+    assert_eq!(
+        sent_req.header("x-amz-content-sha256"),
+        Some("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+    ); // SHA of zero-length body
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn cached_provider_reuses_credentials_across_requests() -> anyhow::Result<()> {
+    tracing_init();
+
+    let mut server = MockServer::start()?;
+    let region = Region::new("ap-southeast-2");
+    let time_source = StaticTimeSource::from_secs(1673626117); // 2023-01-13 16:08:37 +0000
+    let (provider, calls) = CountingCredentialsProvider::new();
+    let cached = CachedCredentialsProvider::new(provider);
+    let client = server.client_with(|b| {
+        b.auth(opensearch::auth::Credentials::AwsSigV4(
+            SharedCredentialsProvider::new(cached),
+            region,
+        ))
+        .service_name("custom")
+        .sigv4_time_source(time_source.into())
+        .header(HOST, LOCALHOST)
+    });
+
+    let _ = client.ping().send().await?;
+    let _ = client.ping().send().await?;
+
+    let _ = server.received_request().await?;
+    let _ = server.received_request().await?;
+
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
 
     Ok(())
 }


### PR DESCRIPTION
### Description

Adds `auth::cache::CachedCredentialsProvider`, an opt-in wrapper for AWS `ProvideCredentials` implementations.

`opensearch-rs` currently calls `provide_credentials()` directly before each SigV4 signature. That bypasses the AWS SDK client's `IdentityCache::lazy()` pipeline, so metadata-backed providers such as ECS task roles or EC2 instance profiles can perform a credential lookup per signed OpenSearch request.

This helper caches resolved credentials until shortly before expiry. Existing behavior is unchanged unless users explicitly wrap their provider.

### Design notes

- The API is intentionally a small `ProvideCredentials` adapter because I could not find a modern AWS SDK for Rust drop-in wrapper that caches `Credentials` directly.
- The 10 second default buffer matches `aws_smithy_runtime`'s `IdentityCache::lazy()` default.
- The default jitter fraction is `0.5`, also matching `IdentityCache::lazy()`, to spread refreshes across clients with the same credential expiry.
- Cache hits use `std::sync::RwLock` without `.await`; refreshes use `tokio::sync::Mutex` so concurrent stale readers fan in to one provider call.
- `with_time_source` lets users align cache freshness checks with a custom SigV4 signing time source.
- `IdentityCache::lazy()` and `ExpiringCache` were considered, but they are SDK-runtime abstractions rather than direct `ProvideCredentials` adapters.

### References

- AWS SDK for Rust identity cache: https://docs.rs/aws-smithy-runtime/latest/aws_smithy_runtime/client/identity/struct.IdentityCache.html
- `LazyCacheBuilder` defaults for buffer time and jitter: https://docs.rs/aws-smithy-runtime/latest/aws_smithy_runtime/client/identity/struct.LazyCacheBuilder.html
- `SharedCredentialsProvider` is a shared wrapper, not a cache: https://docs.rs/aws-credential-types/latest/aws_credential_types/provider/struct.SharedCredentialsProvider.html

### Issues Resolved

Closes #418

### Verification

- `cargo test -p opensearch --features aws-auth auth::cache --no-default-features`
- `cargo test -p opensearch --features aws-auth --test aws_auth --no-default-features`
- `cargo test -p opensearch --features aws-auth --doc --no-default-features`
- `cargo check -p opensearch --all-features`

### Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.
