### PR TITLE
ci: link scheduled integration failure jobs

### DIFF
--- a/.github/test-failure-issue-template.md
+++ b/.github/test-failure-issue-template.md
@@ -3,3 +3,5 @@ title: Integration tests against the server failing
 labels: bug, test-failure
 ---
 Integration tests against the server have failed. Please look into it to determine and fix the cause of failure.
+
+[View the failed job]({{ env.FAILURE_JOB_URL }})

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -233,6 +233,7 @@ jobs:
         uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2
         env:
           GITHUB_TOKEN: ${{ steps.github_app_token.outputs.token }}
+          FAILURE_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ job.check_run_id }}
         with:
           filename: ./client/.github/test-failure-issue-template.md
           update_existing: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump `codecov/codecov-action` from 5 to 6 ([#412](https://github.com/opensearch-project/opensearch-rs/pull/412))
 
 ### Changed
+- Include a direct link to the failed job in scheduled integration-test failure issues ([#256](https://github.com/opensearch-project/opensearch-rs/issues/256))
 - Changed documentation link in Cargo.toml to utilize standard docs.rs generation ([#323](https://github.com/opensearch-project/opensearch-rs/pull/323))
 
 ### Deprecated


### PR DESCRIPTION
## Summary

- expose the current matrix job URL to the scheduled-failure issue action
- render a direct "View the failed job" link in the issue body
- record the CI behavior change in the unreleased changelog

Closes #256.

## Validation

- parsed `.github/workflows/test.yml` and asserted the failure step URL contains both `github.run_id` and `job.check_run_id`
- rendered the issue template with a representative URL and verified the resulting Markdown link
- `git diff --check`

The URL shape follows the GitHub Actions job context documentation and established workflow usage: `/actions/runs/{run_id}/job/{check_run_id}`. The scheduled failure path itself cannot be triggered safely from a fork because it is restricted to scheduled runs in the upstream repository.