### PR TITLE
Bump lycheeverse/lychee-action from 2.8.0 to 2.9.0

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: lychee Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
           args: --accept=200,403,429  "**/*.html" "**/*.md" "**/*.txt" "**/*.json" --exclude "file:///github/workspace/*"
           fail: true

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -47,7 +47,7 @@ The following information will help in getting up and running.
   cargo install --force cargo-make
   ```
 
-- [**Packages**]()
+- [**Packages**](#)
 
   Use your preferred package manager to install the following packages:
   


### PR DESCRIPTION
### Description
Bump lycheeverse/lychee-action from 2.8.0 to 2.9.0

### Issues Resolved
Takes on https://github.com/opensearch-project/opensearch-rs/pull/454

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
