### PR TITLE
outSupport boolean-style deprecated fields in the API generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - `ConnectionPool::next` now returns a `Connection` wrapping an `Arc<Url>`, not a reference. ([#391](https://github.com/opensearch-project/opensearch-rs/pull/391))
 
 ### Added
+- Added support for boolean-style `deprecated` fields on URL parts in the REST API spec to the API generator, as used by newer OpenSearch specs
 - Added middleware types to allow intercepting construction and handling of the underlying `reqwest` client & requests ([#232](https://github.com/opensearch-project/opensearch-rs/pull/232)) 
 - Added `auth::cache::CachedCredentialsProvider`, an opt-in helper that caches AWS credentials between requests so users can avoid querying ECS / EC2 metadata endpoints on every signed request ([#419](https://github.com/opensearch-project/opensearch-rs/pull/419))
 

--- a/api_generator/src/generator/mod.rs
+++ b/api_generator/src/generator/mod.rs
@@ -131,8 +131,32 @@ pub struct Type {
     pub options: Vec<Value>,
     #[serde(default)]
     pub default: Option<Value>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_deprecated")]
     pub deprecated: Option<Deprecated>,
+}
+
+/// Deserializes the `deprecated` field of a param or part, which may either be
+/// a boolean (e.g. `"deprecated": true`) or an object with `version` and
+/// `description` fields
+fn deserialize_deprecated<'de, D>(deserializer: D) -> Result<Option<Deprecated>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum BoolOrDeprecated {
+        Bool(bool),
+        Object(Deprecated),
+    }
+
+    match Option::<BoolOrDeprecated>::deserialize(deserializer)? {
+        Some(BoolOrDeprecated::Bool(true)) => Ok(Some(Deprecated {
+            version: String::new(),
+            description: String::from("Deprecated"),
+        })),
+        Some(BoolOrDeprecated::Bool(false)) | None => Ok(None),
+        Some(BoolOrDeprecated::Object(d)) => Ok(Some(d)),
+    }
 }
 
 /// The type of the param or part


### PR DESCRIPTION
Newer OpenSearch REST API specs mark URL parts as deprecated with a boolean (e.g. '"deprecated": true' on the scroll_id part of clear_scroll.json in the main branch), while the generator only accepted the object form with version and description, failing to parse such specs.

Accept both forms when deserializing the spec.

### Description
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
