### PR TITLE
Fix multi-range version skips in yaml_test_runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 
 ### Fixed
+- Fixed `yaml_test_runner` ignoring comma-separated multi-range version skips in YAML tests (e.g. `" - 2.6.99, 2.13.0 - "`)
 
 ### Security
 

--- a/yaml_test_runner/src/step/skip.rs
+++ b/yaml_test_runner/src/step/skip.rs
@@ -37,7 +37,7 @@ use semver::Op;
 use serde_yaml::Value;
 
 pub struct Skip {
-    version_requirements: Option<semver::VersionReq>,
+    version_requirements: Option<Vec<semver::VersionReq>>,
     version: Option<String>,
     reason: Option<String>,
     features: Option<Vec<String>>,
@@ -68,36 +68,51 @@ impl Skip {
         }
     }
 
-    /// Converts the version range specified in the yaml test into a [semver::VersionReq]
-    fn parse_version_requirements(version: &Option<String>) -> Option<semver::VersionReq> {
+    /// Converts the version range(s) specified in the yaml test into [semver::VersionReq]s.
+    /// A version specification may contain multiple comma-separated ranges,
+    /// e.g. `" - 2.6.99, 2.13.0 - "`
+    fn parse_version_requirements(version: &Option<String>) -> Option<Vec<semver::VersionReq>> {
         if let Some(v) = version {
             if v.to_lowercase() == "all" {
-                Some(semver::VersionReq::STAR)
+                Some(vec![semver::VersionReq::STAR])
             } else {
                 lazy_static! {
                     static ref VERSION_REGEX: Regex =
                         Regex::new(r"^([\w\.]+)?\s*?\-\s*?([\w\.]+)?$").unwrap();
                 }
-                if let Some(c) = VERSION_REGEX.captures(v) {
-                    match (c.get(1), c.get(2)) {
-                        (Some(start), Some(end)) => Some(
-                            semver::VersionReq::parse(
-                                format!(">={},<={}", start.as_str(), end.as_str()).as_ref(),
-                            )
-                            .unwrap(),
-                        ),
-                        (Some(start), None) => Some(
-                            semver::VersionReq::parse(format!(">={}", start.as_str()).as_ref())
-                                .unwrap(),
-                        ),
-                        (None, Some(end)) => Some(
-                            semver::VersionReq::parse(format!("<={}", end.as_str()).as_ref())
-                                .unwrap(),
-                        ),
-                        (None, None) => None,
-                    }
-                } else {
+                let requirements: Vec<semver::VersionReq> = v
+                    .split(',')
+                    .filter_map(|range| {
+                        if let Some(c) = VERSION_REGEX.captures(range.trim()) {
+                            match (c.get(1), c.get(2)) {
+                                (Some(start), Some(end)) => Some(
+                                    semver::VersionReq::parse(
+                                        format!(">={},<={}", start.as_str(), end.as_str()).as_ref(),
+                                    )
+                                    .unwrap(),
+                                ),
+                                (Some(start), None) => Some(
+                                    semver::VersionReq::parse(
+                                        format!(">={}", start.as_str()).as_ref(),
+                                    )
+                                    .unwrap(),
+                                ),
+                                (None, Some(end)) => Some(
+                                    semver::VersionReq::parse(format!("<={}", end.as_str()).as_ref())
+                                        .unwrap(),
+                                ),
+                                (None, None) => None,
+                            }
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+
+                if requirements.is_empty() {
                     None
+                } else {
+                    Some(requirements)
                 }
             }
         } else {
@@ -135,7 +150,7 @@ impl Skip {
     /// Determines if this instance matches the version
     pub fn skip_version(&self, version: &semver::Version) -> bool {
         match &self.version_requirements {
-            Some(r) => {
+            Some(requirements) => requirements.iter().any(|r| {
                 // Hack because old pre-fork version ranges are for ES versions, but OS reset back to 1.x while still being compatible(ish) with ES 7.10
                 if let Some(es_upper) = r
                     .comparators
@@ -148,7 +163,7 @@ impl Skip {
                 }
 
                 r.matches(version)
-            }
+            }),
             None => false,
         }
     }


### PR DESCRIPTION
### Description

The `yaml_test_runner` currently parses the `version` field of a `skip` step as
a single version range. However, YAML tests may specify multiple
comma-separated ranges, e.g.:

```yaml
skip:
  version: " - 2.6.99, 2.13.0 - "
```

The current regex-based parser fails to match such values, silently dropping
the skip and causing tests to run against versions they were meant to be
skipped on.

This PR changes `Skip::version_requirements` from `Option<semver::VersionReq>`
to `Option<Vec<semver::VersionReq>>`. The version specification is split on
commas, each range is parsed individually, and `skip_version()` now skips if
**any** of the ranges matches the server version. Single-range and `all`
specifications behave exactly as before.

### Issues Resolved
partly #338 

### Check List

- [ ] New functionality includes testing
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [[here](https://github.com/opensearch-project/opensearch-rs/blob/main/CONTRIBUTING.md#developer-certificate-of-origin)](https://github.com/opensearch-project/opensearch-rs/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
````