### PR TITLE
Fix yaml_test_runner parts generation for APIs with no URL parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 
 ### Fixed
+- Fixed `yaml_test_runner` generating an unexpected parts argument for APIs whose paths all have no URL parts (e.g. `cat.cluster_manager` with its deprecated `cat.master` alias path)
 
 ### Security
 

--- a/yaml_test_runner/src/step/do.rs
+++ b/yaml_test_runner/src/step/do.rs
@@ -630,9 +630,20 @@ impl ApiCall {
                 ));
             }
 
-            return match endpoint.url.paths.len() {
-                1 => Ok(None),
-                _ => Ok(Some(quote!(#enum_name::None))),
+            // The generated client method takes no parts argument when every
+            // path of the API has an empty set of parts (e.g. an API with a
+            // deprecated alias path such as cat.cluster_manager), as the parts
+            // enum then only contains a None variant.
+            let has_parts_variants = endpoint
+                .url
+                .paths
+                .iter()
+                .any(|p| !p.path.params().is_empty());
+
+            return if has_parts_variants {
+                Ok(Some(quote!(#enum_name::None)))
+            } else {
+                Ok(None)
             };
         }
 


### PR DESCRIPTION
## Description

For an API whose URL has multiple paths, the `yaml_test_runner` assumes the
generated client method takes a parts enum argument and emits
`{Api}Parts::None`. However, when **every** path of the API has an empty set
of URL parts — e.g. `cat.cluster_manager`, which has a deprecated `cat.master`
alias path — the generated client method takes no parts argument at all, and
the emitted `#enum_name::None` fails to compile.

This PR replaces the path-count heuristic with an explicit check: a parts
argument is only emitted when at least one path actually declares URL params.

### Issues Resolved

partly #338

### Check List

- [ ] New functionality includes testing
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [[here](https://github.com/opensearch-project/opensearch-rs/blob/main/CONTRIBUTING.md#developer-certificate-of-origin)](https://github.com/opensearch-project/opensearch-rs/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).