### PR TITLE
Make deprecation warning header test server-version independent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 
 ### Fixed
+- Fixed the `deprecation_warning_headers` test relying on OpenSearch emitting a Warning header for the legacy `_term` aggregation order, which newer versions no longer do; the test now verifies Warning header parsing against a mock server with customizable response headers
 
 ### Security
 

--- a/opensearch/tests/client.rs
+++ b/opensearch/tests/client.rs
@@ -196,37 +196,22 @@ async fn call_request_timeout_supersedes_global_timeout() -> anyhow::Result<()> 
 
 #[tokio::test]
 async fn deprecation_warning_headers() -> anyhow::Result<()> {
-    let client = client::create();
-    let _ = index_documents(&client).await?;
-    let response = client
+    // OpenSearch 3.x no longer emits Warning headers for the legacy `_term`
+    // aggregation order key, so a mock server is used to verify that the
+    // client correctly parses Warning headers from a response.
+    let mut server = MockServer::builder()
+        .response_header(
+            hyper::header::WARNING,
+            hyper::header::HeaderValue::from_static(
+                "299 OpenSearch \"Deprecated aggregation order key [_term] used, replaced by [_key]\"",
+            ),
+        )
+        .start()?;
+
+    let response = server
+        .client()
         .search(SearchParts::None)
-        .body(json! {
-            {
-              "aggs": {
-                "titles": {
-                  "terms": {
-                    "field": "title.keyword",
-                    "order": [{
-                      "_term": "asc"
-                    }]
-                  }
-                }
-              },
-              "query": {
-                "function_score": {
-                  "functions": [{
-                    "random_score": {
-                      "seed": 1337
-                    }
-                  }],
-                  "query": {
-                    "match_all": {}
-                  }
-                }
-              },
-              "size": 0
-            }
-        })
+        .body(json!({ "query": { "match_all": {} }, "size": 0 }))
         .send()
         .await?;
 

--- a/opensearch/tests/common/server.rs
+++ b/opensearch/tests/common/server.rs
@@ -56,17 +56,29 @@ use super::client::TestClientBuilder;
 struct RequestState {
     requests_tx: mpsc::UnboundedSender<ReceivedRequest>,
     response_delay: Option<Duration>,
+    response_headers: HeaderMap,
     shutdown_rx: watch::Receiver<bool>,
 }
 
 #[derive(Default)]
 pub struct MockServerBuilder {
     response_delay: Option<Duration>,
+    response_headers: HeaderMap,
 }
 
 impl MockServerBuilder {
     pub fn response_delay(mut self, delay: Duration) -> Self {
         self.response_delay = Some(delay);
+        self
+    }
+
+    /// Adds a header to every response returned by the mock server
+    pub fn response_header(
+        mut self,
+        name: hyper::header::HeaderName,
+        value: hyper::header::HeaderValue,
+    ) -> Self {
+        self.response_headers.append(name, value);
         self
     }
 
@@ -78,7 +90,9 @@ impl MockServerBuilder {
         if let Some(response_delay) = state.response_delay {
             sleep(response_delay).await;
         }
-        Ok(Default::default())
+        let mut response = Response::default();
+        response.headers_mut().extend(state.response_headers.clone());
+        Ok(response)
     }
 
     async fn serve_connection(io: TokioIo<TcpStream>, state: RequestState) {
@@ -124,6 +138,7 @@ impl MockServerBuilder {
             RequestState {
                 requests_tx,
                 response_delay: self.response_delay,
+                response_headers: self.response_headers,
                 shutdown_rx,
             },
         );


### PR DESCRIPTION
### Description

The `deprecation_warning_headers` integration test relies on OpenSearch
emitting a `Warning` header when the legacy `_term` aggregation order key is
used. Newer OpenSearch versions (3.x) no longer emit this warning, so the test
fails against them — even though what the test actually verifies is the
client's ability to parse `Warning` headers from a response.

This PR decouples the test from server behavior:

- `MockServerBuilder` gains a `response_header(name, value)` method that adds
  a header to every response returned by the mock server
- `deprecation_warning_headers` now runs against the mock server with a
  preset `Warning` header, verifying the client-side parsing logic directly

The test no longer depends on which deprecations a given server version
happens to emit, making it stable across all OpenSearch versions.

### Issues Resolved

partly #338

### Check List

- [x] New functionality includes testing
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [[here](https://github.com/opensearch-project/opensearch-rs/blob/main/CONTRIBUTING.md#developer-certificate-of-origin)](https://github.com/opensearch-project/opensearch-rs/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).