### PR TITLE
 Add MultiNodeConnectionPool with round-robin node selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Added middleware types to allow intercepting construction and handling of the underlying `reqwest` client & requests ([#232](https://github.com/opensearch-project/opensearch-rs/pull/232)) 
 - Added `auth::cache::CachedCredentialsProvider`, an opt-in helper that caches AWS credentials between requests so users can avoid querying ECS / EC2 metadata endpoints on every signed request ([#419](https://github.com/opensearch-project/opensearch-rs/pull/419))
-- Added `MultiNodeConnectionPool`, a `ConnectionPool` implementation that distributes requests across multiple cluster nodes in round-robin fashion, and a `Transport::multi_node()` convenience constructor
+- Added `MultiNodeConnectionPool`, a `ConnectionPool` implementation that distributes requests across multiple cluster nodes in round-robin fashion, and a `Transport::multi_node()` convenience constructor ([#483](https://github.com/opensearch-project/opensearch-rs/issues/483))
 
 ### Dependencies
 - Bumps `sysinfo` from 0.31.2 to 0.39.1 ([#331](https://github.com/opensearch-project/opensearch-rs/pull/331), [#339](https://github.com/opensearch-project/opensearch-rs/pull/339), [#346](https://github.com/opensearch-project/opensearch-rs/pull/346), [#352](https://github.com/opensearch-project/opensearch-rs/pull/352), [#389](https://github.com/opensearch-project/opensearch-rs/pull/389), [#420](https://github.com/opensearch-project/opensearch-rs/pull/420))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Added middleware types to allow intercepting construction and handling of the underlying `reqwest` client & requests ([#232](https://github.com/opensearch-project/opensearch-rs/pull/232)) 
 - Added `auth::cache::CachedCredentialsProvider`, an opt-in helper that caches AWS credentials between requests so users can avoid querying ECS / EC2 metadata endpoints on every signed request ([#419](https://github.com/opensearch-project/opensearch-rs/pull/419))
+- Added `MultiNodeConnectionPool`, a `ConnectionPool` implementation that distributes requests across multiple cluster nodes in round-robin fashion, and a `Transport::multi_node()` convenience constructor
 
 ### Dependencies
 - Bumps `sysinfo` from 0.31.2 to 0.39.1 ([#331](https://github.com/opensearch-project/opensearch-rs/pull/331), [#339](https://github.com/opensearch-project/opensearch-rs/pull/339), [#346](https://github.com/opensearch-project/opensearch-rs/pull/346), [#352](https://github.com/opensearch-project/opensearch-rs/pull/352), [#389](https://github.com/opensearch-project/opensearch-rs/pull/389), [#420](https://github.com/opensearch-project/opensearch-rs/pull/420))

--- a/opensearch/src/http/transport.rs
+++ b/opensearch/src/http/transport.rs
@@ -57,8 +57,11 @@ use dyn_clone::clone_trait_object;
 use lazy_static::lazy_static;
 use reqwest::ClientBuilder;
 use serde::Serialize;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
 use std::{fmt::Debug, io::Write, time::Duration};
-use std::sync::Arc;
 use url::Url;
 
 #[derive(Debug, thiserror::Error)]
@@ -569,6 +572,22 @@ impl Transport {
         Ok(transport)
     }
 
+    /// Creates a new instance of a [Transport] configured with a
+    /// [MultiNodeConnectionPool] that distributes requests across the
+    /// given node addresses in round-robin fashion.
+    pub fn multi_node<'u, U>(urls: U) -> Result<Transport, Error>
+    where
+        U: IntoIterator<Item = &'u str>,
+    {
+        let urls = urls
+            .into_iter()
+            .map(Url::parse)
+            .collect::<Result<Vec<_>, _>>()?;
+        let conn_pool = MultiNodeConnectionPool::round_robin(urls);
+        let transport = TransportBuilder::new(conn_pool).build()?;
+        Ok(transport)
+    }
+
     /// Creates an asynchronous request that can be awaited
     pub async fn send<B, Q>(
         &self,
@@ -728,6 +747,45 @@ impl ConnectionPool for SingleNodeConnectionPool {
     }
 }
 
+/// A connection pool that manages connections to multiple OpenSearch cluster nodes,
+/// distributing requests across the nodes in round-robin fashion.
+///
+/// All clones of a [MultiNodeConnectionPool] share the same rotation state, so
+/// requests sent through cloned [Transport]s continue the same round-robin sequence.
+#[derive(Debug, Clone)]
+pub struct MultiNodeConnectionPool {
+    connections: Arc<Vec<Connection>>,
+    index: Arc<AtomicUsize>,
+}
+
+impl MultiNodeConnectionPool {
+    /// Creates a new instance of [MultiNodeConnectionPool], selecting [Connection]s
+    /// from the given node addresses in round-robin fashion.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `urls` is empty.
+    pub fn round_robin(urls: Vec<Url>) -> Self {
+        assert!(
+            !urls.is_empty(),
+            "MultiNodeConnectionPool requires at least one url"
+        );
+        let connections = urls.into_iter().map(Connection::new).collect();
+        Self {
+            connections: Arc::new(connections),
+            index: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+}
+
+impl ConnectionPool for MultiNodeConnectionPool {
+    /// Gets a reference to the next [Connection], rotating through the nodes
+    fn next(&self) -> Connection {
+        let i = self.index.fetch_add(1, Ordering::Relaxed);
+        self.connections[i % self.connections.len()].clone()
+    }
+}
+
 #[cfg(test)]
 pub mod tests {
     use super::*;
@@ -789,5 +847,62 @@ pub mod tests {
         let url = Url::parse("http://10.1.2.3/").unwrap();
         let conn = Connection::new(url);
         assert_eq!(conn.url.as_str(), "http://10.1.2.3/");
+    }
+
+    fn multi_node_urls() -> Vec<Url> {
+        vec![
+            Url::parse("http://node1:9200").unwrap(),
+            Url::parse("http://node2:9200").unwrap(),
+            Url::parse("http://node3:9200").unwrap(),
+        ]
+    }
+
+    #[test]
+    fn multi_node_connection_pool_round_robins_nodes() {
+        let pool = MultiNodeConnectionPool::round_robin(multi_node_urls());
+        let selected: Vec<String> = (0..6).map(|_| pool.next().url.to_string()).collect();
+        assert_eq!(
+            selected,
+            vec![
+                "http://node1:9200/",
+                "http://node2:9200/",
+                "http://node3:9200/",
+                "http://node1:9200/",
+                "http://node2:9200/",
+                "http://node3:9200/",
+            ]
+        );
+    }
+
+    #[test]
+    fn multi_node_connection_pool_clones_share_rotation_state() {
+        let pool = MultiNodeConnectionPool::round_robin(multi_node_urls());
+        let clone = pool.clone();
+        assert_eq!(pool.next().url.as_str(), "http://node1:9200/");
+        assert_eq!(clone.next().url.as_str(), "http://node2:9200/");
+        assert_eq!(pool.next().url.as_str(), "http://node3:9200/");
+    }
+
+    #[test]
+    #[should_panic(expected = "at least one url")]
+    fn multi_node_connection_pool_panics_on_empty_urls() {
+        MultiNodeConnectionPool::round_robin(Vec::new());
+    }
+
+    #[test]
+    fn transport_multi_node_builds_from_str_urls() {
+        let transport = Transport::multi_node(["http://node1:9200", "http://node2:9200"]).unwrap();
+        assert_eq!(
+            transport.conn_pool.next().url.as_str(),
+            "http://node1:9200/"
+        );
+        assert_eq!(
+            transport.conn_pool.next().url.as_str(),
+            "http://node2:9200/"
+        );
+        assert_eq!(
+            transport.conn_pool.next().url.as_str(),
+            "http://node1:9200/"
+        );
     }
 }


### PR DESCRIPTION
### Description

Adds `MultiNodeConnectionPool`, a `ConnectionPool` implementation that distributes requests across multiple cluster nodes in round-robin fashion, plus a `Transport::multi_node()` convenience constructor mirroring `Transport::single_node()`.

Until now the client only shipped `SingleNodeConnectionPool`, so every request went to one node. For self-managed clusters without an external load balancer this concentrates all coordinating work on a single node and makes it a single point of failure. Other OpenSearch clients (go, py, java) provide multi-node pools out of the box.

Design notes:

- Node selection uses an atomic counter with modulo indexing; `next()` is lock-free
- Clones of the pool share rotation state (`Arc<AtomicUsize>`), so cloned `Transport`s continue the same round-robin sequence instead of each starting from the first node
- Node selection is independent of socket-level pooling: reqwest already keeps per-host connections alive, so each node retains its own persistent connections
- Dead-node marking, health checks, and `_nodes/info`-based discovery are intentionally out of scope and can build on this later

Usage:

```rust
let transport = Transport::multi_node(["http://node1:9200", "http://node2:9200"])?;
let client = OpenSearch::new(transport);
```

### Testing

- 4 new unit tests in `http::transport::tests`: round-robin ordering over multiple cycles, shared rotation state across clones, panic on empty url list, and `Transport::multi_node()` construction
- `cargo test -p opensearch --lib http::transport`: 9 passed, 0 failed
- `cargo fmt --check` and `cargo clippy` clean for the new code

### Issues Resolved

Resolves #483

### Check List

- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
de